### PR TITLE
Disable all optimizations by default

### DIFF
--- a/aot-cli/build.gradle.kts
+++ b/aot-cli/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation(mn.spock)
     testImplementation(projects.aotCore)
     testImplementation(projects.aotStdOptimizers)
+    testImplementation(mn.micronaut.core)
 
     testAotRuntime(mn.micronaut.context)
     testAotRuntime(mn.micronaut.inject)

--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -9,6 +9,7 @@ import io.micronaut.aot.std.sourcegen.KnownMissingTypesSourceGenerator
 import io.micronaut.aot.std.sourcegen.LogbackConfigurationSourceGenerator
 import io.micronaut.aot.std.sourcegen.PublishersSourceGenerator
 import io.micronaut.aot.std.sourcegen.SealedEnvironmentSourceGenerator
+import io.micronaut.aot.std.sourcegen.YamlPropertySourceGenerator
 import spock.lang.Specification
 import spock.lang.TempDir
 import spock.lang.Unroll
@@ -50,6 +51,7 @@ ${KnownMissingTypesSourceGenerator.OPTION.toPropertiesSample()}"""],
                 [AbstractStaticServiceLoaderSourceGenerator.DESCRIPTION, """serviceloading.${runtime}.enabled = true
 ${AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES.toPropertiesSample()}
 ${AbstractStaticServiceLoaderSourceGenerator.REJECTED_CLASSES.toPropertiesSample()}"""],
+                [YamlPropertySourceGenerator.DESCRIPTION, 'yaml.to.java.config.enabled = true'],
                 [ConstantPropertySourcesSourceGenerator.DESCRIPTION, "sealed.property.source.enabled = true"],
         ].findAll().collect { desc, c -> """# $desc
 $c

--- a/aot-core/src/main/java/io/micronaut/aot/core/AOTSourceGenerator.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/AOTSourceGenerator.java
@@ -81,6 +81,19 @@ public interface AOTSourceGenerator {
     }
 
     /**
+     * Returns a list of generators which are directly managed (or instantiated_
+     * by this source generator. Such optimizers are typically not registered as
+     * services because they make no sense in isolation.
+     * This method should be used for introspection only.
+     *
+     * @return the list of sub features
+     */
+    @NonNull
+    default List<AOTSourceGenerator> getSubGenerators() {
+        return Collections.emptyList();
+    }
+
+    /**
      * Returns the set of configuration keys which affect
      * the configuration of this source generator.
      * @return a set of configuration keys

--- a/aot-core/src/main/java/io/micronaut/aot/core/Configuration.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/Configuration.java
@@ -110,6 +110,18 @@ public interface Configuration {
     }
 
     /**
+     * Returns true if a particular optimizer is enabled, independently
+     * of the runtime. All features need to be explicitly enabled by
+     * configuration.
+     *
+     * @param featureId the feature id
+     * @return true if the feature is enabled
+     */
+    default boolean isFeatureEnabled(@NonNull String featureId) {
+        return booleanValue(featureId + ".enabled", false);
+    }
+
+    /**
      * Returns the target runtime for optimizations.
      * @return the target runtime
      */

--- a/aot-core/src/main/java/io/micronaut/aot/core/config/SourceGeneratorLoader.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/config/SourceGeneratorLoader.java
@@ -50,7 +50,7 @@ public class SourceGeneratorLoader {
         Configuration configuration = context.getConfiguration();
         return sourceGeneratorStream()
                 .filter(sg -> sg.isEnabledOn(runtime))
-                .filter(sg -> configuration.booleanValue(sg.getId() + ".enabled", true))
+                .filter(sg -> configuration.isFeatureEnabled(sg.getId()))
                 .sorted(EXECUTION_ORDER)
                 .peek(sg -> sg.init(context))
                 .collect(Collectors.toList());

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/YamlPropertySourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/YamlPropertySourceGenerator.java
@@ -39,6 +39,7 @@ import java.util.Optional;
  */
 public class YamlPropertySourceGenerator extends AbstractSourceGenerator {
     public static final String ID = "yaml.to.java.config";
+    public static final String DESCRIPTION = "Converts YAML configuration files to Java configuration";
     private static final Logger LOGGER = LoggerFactory.getLogger(YamlPropertySourceGenerator.class);
 
     private final Collection<String> resources;
@@ -51,6 +52,11 @@ public class YamlPropertySourceGenerator extends AbstractSourceGenerator {
     @NonNull
     public String getId() {
         return ID;
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of(DESCRIPTION);
     }
 
     @Override


### PR DESCRIPTION
This commit changes the default of optimizations from "true" to "false".
In addition, introspection has been added for optimizers which internally
rely on other optimizers which shouldn't be instantiated via the service
loading infrastructure. This lets us document more properly all available
optimizations.