### PR TITLE
Fix exit code not propagated

### DIFF
--- a/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
+++ b/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
@@ -132,7 +132,11 @@ public class Main implements Runnable, ConfigKeys {
                 .collect(Collectors.toList());
     }
 
+    public static int execute(String[] args) {
+        return new CommandLine(new Main()).execute(args);
+    }
+
     public static void main(String[] args) {
-        new CommandLine(new Main()).execute(args);
+        System.exit(execute(args));
     }
 }

--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -28,7 +28,7 @@ class CliTest extends Specification {
 
         when:
         isolate {
-            Main.main(
+            Main.execute(
                     '--classpath', classpath,
                     '--optimizer-classpath', classpath,
                     '--runtime', runtime,


### PR DESCRIPTION
Without doing this, even if the app throws an exception, the app
exit as if it succeeded.