### PR TITLE
Do not use `:` in separator

### DIFF
--- a/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
+++ b/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
@@ -81,7 +81,7 @@ public class Main implements Runnable, ConfigKeys {
             } catch (URISyntaxException e) {
                 return null;
             }
-        }).collect(Collectors.joining(":")));
+        }).collect(Collectors.joining(",")));
         props.put(GENERATED_PACKAGE, packageName);
         if (outputDirectory != null) {
             props.put(OUTPUT_DIRECTORY, outputDirectory.getAbsolutePath());

--- a/aot-core/src/main/java/io/micronaut/aot/core/Configuration.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/Configuration.java
@@ -67,14 +67,14 @@ public interface Configuration {
     /**
      * Returns a list of strings from a configuration entry.
      * The value is assumed to be of type String and will be splitted
-     * using the "," and ":" separators
+     * using the "," and ";" separators
      *
      * @param key the configuration key
      * @return a list of strings, or an empty list when missing
      */
     @NonNull
     default List<String> stringList(@NonNull String key) {
-        return stringList(key, "[,:]\\s*");
+        return stringList(key, "[,;]\\s*");
     }
 
     /**


### PR DESCRIPTION
Since this is used in Windows paths.