### PR TITLE
Represent AOT module metadata via annotations

### DIFF
--- a/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
+++ b/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
@@ -121,7 +121,7 @@ public class Main implements Runnable, ConfigKeys {
         }
     }
 
-    private static List<URL> toURLs(String classpathString ) {
+    private static List<URL> toURLs(String classpathString) {
         return Arrays.stream(classpathString.split("[,;" + File.pathSeparator + "]"))
                 .map(File::new)
                 .map(File::toURI).map(uri -> {

--- a/aot-core/src/main/java/io/micronaut/aot/core/AOTModule.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/AOTModule.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aot.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation which must be present on AOT optimizers.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface AOTModule {
+    /**
+     * A unique identifier for this source generator.
+     * @return the id
+     */
+    String id();
+
+    /**
+     * Returns a description for this source generator.
+     * Description is optional because some code generators
+     * are purely internal and not exposed to users.
+     * @return a description or an empty options
+     */
+    String description() default "";
+
+    /**
+     * Returns the identifiers of source generators which must
+     * be executed before this generator is called.
+     * @return the list of ids
+     */
+    String[] dependencies() default {};
+
+    /**
+     * Returns a list of generators which are directly managed (or instantiated_
+     * by this source generator. Such optimizers are typically not registered as
+     * services because they make no sense in isolation.
+     * This method should be used for introspection only.
+     *
+     * @return the list of sub features
+     */
+    Class<? extends AOTSourceGenerator>[] subgenerators() default {};
+
+    /**
+     * Returns the set of configuration keys which affect
+     * the configuration of this source generator.
+     * @return a set of configuration keys
+     */
+    Option[] options() default {};
+
+    /**
+     * Returns the runtimes this module is valid for.
+     * @return the list of runtimes this module applies to.
+     */
+    Runtime[] enabledOn() default { Runtime.JIT, Runtime.NATIVE };
+
+}

--- a/aot-core/src/main/java/io/micronaut/aot/core/AOTSourceGenerator.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/AOTSourceGenerator.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * A source generator is the main entity of the AOT project.
@@ -39,70 +38,10 @@ import java.util.Set;
  *     <li>one or more source files</li>
  *     <li>one or more resource files</li>
  * </ul>
+ *
+ * Source generators must be annotated with {@link AOTModule}.
  */
 public interface AOTSourceGenerator {
-    /**
-     * A unique identifier for this source generator.
-     * @return the id
-     */
-    @NonNull
-    String getId();
-
-    /**
-     * Returns a description for this source generator.
-     * Description is optional because some code generators
-     * are purely internal and not exposed to users.
-     * @return a description or an empty options
-     */
-    @NonNull
-    default Optional<String> getDescription() {
-        return Optional.empty();
-    }
-
-    /**
-     * Determines if this source generator should be enabled
-     * when targetting a particular runtime.
-     * @param runtime the target runtime
-     * @return true if the source generator should be enabled
-     */
-    @NonNull
-    default boolean isEnabledOn(@NonNull Runtime runtime) {
-        return true;
-    }
-
-    /**
-     * Returns the identifiers of source generators which must
-     * be executed before this generator is called.
-     * @return the list of ids
-     */
-    @NonNull
-    default Set<String> getDependencies() {
-        return Collections.emptySet();
-    }
-
-    /**
-     * Returns a list of generators which are directly managed (or instantiated_
-     * by this source generator. Such optimizers are typically not registered as
-     * services because they make no sense in isolation.
-     * This method should be used for introspection only.
-     *
-     * @return the list of sub features
-     */
-    @NonNull
-    default List<AOTSourceGenerator> getSubGenerators() {
-        return Collections.emptyList();
-    }
-
-    /**
-     * Returns the set of configuration keys which affect
-     * the configuration of this source generator.
-     * @return a set of configuration keys
-     */
-    @NonNull
-    default Set<Option> getConfigurationOptions() {
-        return Collections.emptySet();
-    }
-
     /**
      * Initializes the source generator.
      * @param context the context to be injected

--- a/aot-core/src/main/java/io/micronaut/aot/core/Option.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/Option.java
@@ -15,117 +15,26 @@
  */
 package io.micronaut.aot.core;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
-
-import java.util.Optional;
-
 /**
  * Describes a configuration option of a source generator.
  */
-public final class Option {
-    private final String key;
-    private final String description;
-    private final String sampleValue;
-
-    private Option(@NonNull String key,
-                  @Nullable String description,
-                  @Nullable String sampleValue) {
-        this.key = key;
-        this.description = description;
-        this.sampleValue = sampleValue;
-    }
-
+public @interface Option {
     /**
      * Returns the key used to configure this option.
      * @return the key, as found in properties
      */
-    @NonNull
-    public String getKey() {
-        return key;
-    }
+    String key();
 
     /**
      * Returns a description of this configuration option.
      * @return the description
      */
-    @NonNull
-    public Optional<String> getDescription() {
-        return Optional.ofNullable(description);
-    }
+    String description() default "";
 
     /**
      * Returns a sample value for this option, if any.
      * @return a sample value
      */
-    @NonNull
-    public Optional<String> getSampleValue() {
-        return Optional.ofNullable(sampleValue);
-    }
+    String sampleValue() default "";
 
-    /**
-     * Returns a string representation of the option, for
-     * use in properties files.
-     * @return a sample
-     */
-    public String toPropertiesSample() {
-        StringBuilder sb = new StringBuilder();
-        if (description != null) {
-            sb.append("# ").append(description).append("\n");
-        }
-        sb.append(key).append(" = ");
-        if (sampleValue != null) {
-            sb.append(sampleValue);
-        }
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        Option option = (Option) o;
-
-        return key.equals(option.key);
-    }
-
-    @Override
-    public int hashCode() {
-        return key.hashCode();
-    }
-
-    /**
-     * A simple option without description nor sample.
-     * @param key the key
-     * @return an option
-     */
-    public static Option of(@NonNull String key) {
-        return new Option(key, null, null);
-    }
-
-    /**
-     * A simple option without sample.
-     * @param key the key
-     * @param description the description
-     * @return an option
-     */
-    public static Option of(@NonNull String key, @NonNull String description) {
-        return new Option(key, description, null);
-    }
-
-    /**
-     * Builds an option descriptor.
-     * @param key the key
-     * @param description the description
-     * @param sampleValue a sample value for this option
-     * @return an option
-     */
-    public static Option of(@NonNull String key, @NonNull String description, @NonNull String sampleValue) {
-        return new Option(key, description, sampleValue);
-    }
 }

--- a/aot-core/src/main/java/io/micronaut/aot/core/config/MetadataUtils.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/config/MetadataUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aot.core.config;
+
+import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.AOTSourceGenerator;
+import io.micronaut.aot.core.Option;
+import io.micronaut.aot.core.Runtime;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Runtime reflection utils for analyzing AOT modules.
+ */
+public class MetadataUtils {
+    /**
+     * Returns the AOT module annotation for a class, if present.
+     * @param clazz the class to look for
+     * @return the module annotation.
+     */
+    public static Optional<AOTModule> findMetadata(Class<?> clazz) {
+        return Optional.ofNullable(clazz.getAnnotation(AOTModule.class));
+    }
+
+    /**
+     * Returns the option with the corresponding name. If
+     * the supplied class is not annotated with {@link AOTModule}
+     * invocation will fail.
+     * @param clazz the AOT module class
+     * @param name the name of the option
+     * @return the corresponding option
+     */
+    public static Option findOption(Class<?> clazz, String name) {
+        return findMetadata(clazz).flatMap(aotModule -> Arrays.stream(aotModule.options()).filter(option -> option.key().equals(name)).findFirst()).orElseThrow(() -> new IllegalArgumentException("No option found with name " + name + " on " + clazz));
+    }
+
+    /**
+     * Returns a string representation of the option, for
+     * use in properties files.
+     * @param option the option to convert to sample text.
+     * @return a sample
+     */
+    public static String toPropertiesSample(Option option) {
+        StringBuilder sb = new StringBuilder();
+        String description = option.description();
+        if (!description.isEmpty()) {
+            sb.append("# ").append(description).append("\n");
+        }
+        String key = option.key();
+        sb.append(key).append(" = ");
+        String sampleValue = option.sampleValue();
+        sb.append(sampleValue);
+        return sb.toString();
+    }
+
+    public static boolean isEnabledOn(Runtime runtime, AOTSourceGenerator module) {
+        return findMetadata(module.getClass())
+                .map(aotModule -> isEnabledOn(runtime, aotModule))
+                .orElse(false);
+    }
+
+    public static boolean isEnabledOn(Runtime runtime, AOTModule module) {
+        return Arrays.asList(module.enabledOn()).contains(runtime);
+    }
+}

--- a/aot-core/src/main/java/io/micronaut/aot/core/sourcegen/ApplicationContextConfigurerGenerator.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/sourcegen/ApplicationContextConfigurerGenerator.java
@@ -52,12 +52,6 @@ public class ApplicationContextConfigurerGenerator extends AbstractSourceGenerat
 
     @Override
     @NonNull
-    public String getId() {
-        return ID;
-    }
-
-    @Override
-    @NonNull
     public List<JavaFile> generateSourceFiles() {
         List<JavaFile> allFiles = new ArrayList<>();
         for (AOTSourceGenerator sourceGenerator : sourceGenerators) {

--- a/aot-core/src/test/groovy/io/micronaut/aot/core/sourcegen/ApplicationContextConfigurerGeneratorTest.groovy
+++ b/aot-core/src/test/groovy/io/micronaut/aot/core/sourcegen/ApplicationContextConfigurerGeneratorTest.groovy
@@ -18,6 +18,7 @@ package io.micronaut.aot.core.sourcegen
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.TypeSpec
+import io.micronaut.aot.core.AOTModule
 import io.micronaut.aot.core.AOTSourceGenerator
 import io.micronaut.context.ApplicationContextConfigurer
 import io.micronaut.core.annotation.NonNull
@@ -107,17 +108,12 @@ class SomeClass {
         }
     }
 
+    @AOTModule(id = "static-init")
     private static class GeneratorWithStaticInit extends AbstractSourceGenerator {
         private final String name
 
         protected GeneratorWithStaticInit(String name) {
             this.name = name
-        }
-
-        @NotNull
-        @Override
-        String getId() {
-            "static-init"
         }
 
         @NonNull
@@ -130,18 +126,12 @@ class SomeClass {
         }
     }
 
+    @AOTModule(id = "class-generating")
     private class ClassGenerating extends AbstractSingleClassFileGenerator {
         @Override
         protected JavaFile generate() {
             JavaFile.builder(packageName, TypeSpec.classBuilder("SomeClass").build())
                     .build()
-        }
-
-        @NotNull
-        @Override
-        @NonNull
-        String getId() {
-            "class-generating"
         }
     }
 }

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/ConstantPropertySourcesSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/ConstantPropertySourcesSourceGenerator.java
@@ -19,6 +19,7 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
+import io.micronaut.aot.core.AOTModule;
 import io.micronaut.aot.core.sourcegen.AbstractSourceGenerator;
 import io.micronaut.context.env.CachedEnvironment;
 import io.micronaut.context.env.ConstantPropertySources;
@@ -29,10 +30,8 @@ import io.micronaut.core.util.EnvironmentProperties;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -40,32 +39,17 @@ import java.util.stream.Collectors;
  * {@link PropertySource} which properties are known at build time
  * (and constant).
  */
+@AOTModule(
+        id = ConstantPropertySourcesSourceGenerator.ID,
+        description = ConstantPropertySourcesSourceGenerator.DESCRIPTION,
+        dependencies = {
+                JitStaticServiceLoaderSourceGenerator.ID,
+                NativeStaticServiceLoaderSourceGenerator.ID
+        }
+)
 public class ConstantPropertySourcesSourceGenerator extends AbstractSourceGenerator {
     public static final String ID = "sealed.property.source";
     public static final String DESCRIPTION = "Precomputes property sources at build time";
-
-    @Override
-    @NonNull
-    public String getId() {
-        return ID;
-    }
-
-    @Override
-    @NonNull
-    public Optional<String> getDescription() {
-        return Optional.of(DESCRIPTION);
-    }
-
-    @Override
-    @NonNull
-    public Set<String> getDependencies() {
-        return new HashSet<String>() {
-            {
-                add(JitStaticServiceLoaderSourceGenerator.ID);
-                add(NativeStaticServiceLoaderSourceGenerator.ID);
-            }
-        };
-    }
 
     @Override
     @NonNull

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/EnvironmentPropertiesSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/EnvironmentPropertiesSourceGenerator.java
@@ -19,6 +19,7 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
+import io.micronaut.aot.core.AOTModule;
 import io.micronaut.aot.core.sourcegen.AbstractSourceGenerator;
 import io.micronaut.context.env.CachedEnvironment;
 import io.micronaut.core.annotation.NonNull;
@@ -36,6 +37,10 @@ import java.util.stream.Collectors;
  * A code generator which is responsible for precomputing the Micronaut property
  * names from environment variable names at build time.
  */
+@AOTModule(
+        id = EnvironmentPropertiesSourceGenerator.ID,
+        description = EnvironmentPropertiesSourceGenerator.DESCRIPTION
+)
 public class EnvironmentPropertiesSourceGenerator extends AbstractSourceGenerator {
     public static final String ID = "precompute.environment.properties";
     public static final String DESCRIPTION = "Precomputes Micronaut configuration property keys from the current environment variables";
@@ -48,18 +53,6 @@ public class EnvironmentPropertiesSourceGenerator extends AbstractSourceGenerato
 
     public EnvironmentPropertiesSourceGenerator() {
         this(CachedEnvironment.getenv());
-    }
-
-    @Override
-    @NonNull
-    public String getId() {
-        return ID;
-    }
-
-    @Override
-    @NonNull
-    public Optional<String> getDescription() {
-        return Optional.of(DESCRIPTION);
     }
 
     @Override

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGenerator.java
@@ -21,8 +21,9 @@ import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
+import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.Option;
 import io.micronaut.aot.core.Runtime;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.io.service.SoftServiceLoader;
 
 import java.util.Arrays;
@@ -42,13 +43,26 @@ import static javax.lang.model.element.Modifier.STATIC;
  * A specialized version of static service loader generator aimed
  * at execution in JIT mode.
  */
+@AOTModule(
+        id = JitStaticServiceLoaderSourceGenerator.ID,
+        description = AbstractStaticServiceLoaderSourceGenerator.DESCRIPTION,
+        options = {
+                @Option(
+                        key = "service.types",
+                        description = "The list of service types to be scanned (comma separated)",
+                        sampleValue = "io.micronaut.Service1,io.micronaut.Service2"
+                ),
+                @Option(
+                        key = "serviceloading.rejected.impls",
+                        description = "A list of implementation types which shouldn't be included in the final application (comma separated)",
+                        sampleValue = "com.Misc,org.Bar"
+                )
+        },
+        enabledOn = Runtime.JIT,
+        subgenerators = { YamlPropertySourceGenerator.class }
+)
 public class JitStaticServiceLoaderSourceGenerator extends AbstractStaticServiceLoaderSourceGenerator {
     public static final String ID = "serviceloading.jit";
-
-    @Override
-    public boolean isEnabledOn(@NonNull Runtime runtime) {
-        return runtime == Runtime.JIT;
-    }
 
     protected final void generateFindAllMethod(Predicate<String> rejectedClasses,
                                                String serviceName,
@@ -113,9 +127,4 @@ public class JitStaticServiceLoaderSourceGenerator extends AbstractStaticService
         factory.addMethod(method.build());
     }
 
-    @Override
-    @NonNull
-    public String getId() {
-        return ID;
-    }
 }

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGenerator.java
@@ -28,6 +28,7 @@ import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
+import io.micronaut.aot.core.AOTModule;
 import io.micronaut.aot.core.sourcegen.AbstractSingleClassFileGenerator;
 import io.micronaut.core.annotation.NonNull;
 import org.slf4j.Logger;
@@ -36,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import javax.lang.model.element.Modifier;
 import java.io.File;
 import java.util.Locale;
-import java.util.Optional;
 
 /**
  * A source generator responsible for converting a logback.xml configuration into
@@ -44,22 +44,14 @@ import java.util.Optional;
  *
  * Note: for now the implementation does NOT do that, it's hardcoded!
  */
+@AOTModule(
+        id = LogbackConfigurationSourceGenerator.ID,
+        description = LogbackConfigurationSourceGenerator.DESCRIPTION
+)
 public class LogbackConfigurationSourceGenerator extends AbstractSingleClassFileGenerator {
     public static final String ID = "logback.xml.to.java";
     public static final String DESCRIPTION = "Replaces logback.xml with a pure Java configuration (NOT YET IMPLEMENTED!)";
     private static final Logger LOGGER = LoggerFactory.getLogger(LogbackConfigurationSourceGenerator.class);
-
-    @Override
-    @NonNull
-    public String getId() {
-        return ID;
-    }
-
-    @Override
-    @NonNull
-    public Optional<String> getDescription() {
-        return Optional.of(DESCRIPTION);
-    }
 
     @Override
     @NonNull

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/MapPropertySourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/MapPropertySourceGenerator.java
@@ -19,6 +19,7 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
+import io.micronaut.aot.core.AOTModule;
 import io.micronaut.aot.core.sourcegen.AbstractSingleClassFileGenerator;
 import io.micronaut.context.env.MapPropertySource;
 import io.micronaut.core.annotation.Generated;
@@ -34,8 +35,11 @@ import static javax.lang.model.element.Modifier.PUBLIC;
  * A source generator which generates a map property source with a fixed
  * set of values at build time.
  */
+@AOTModule(
+        id = MapPropertySourceGenerator.BASE_ID
+)
 public class MapPropertySourceGenerator extends AbstractSingleClassFileGenerator {
-    public static final String BASE_ID = "map.property.";
+    public static final String BASE_ID = "map.property";
 
     private final String resourceName;
     private final Map<String, Object> values;
@@ -45,12 +49,6 @@ public class MapPropertySourceGenerator extends AbstractSingleClassFileGenerator
             Map<String, Object> values) {
         this.resourceName = resourceName;
         this.values = values;
-    }
-
-    @Override
-    @NonNull
-    public String getId() {
-        return BASE_ID + resourceName;
     }
 
     private CodeBlock generateMap() {

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGenerator.java
@@ -20,8 +20,9 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
+import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.Option;
 import io.micronaut.aot.core.Runtime;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.io.service.SoftServiceLoader;
 
 import java.util.ArrayList;
@@ -36,19 +37,26 @@ import static javax.lang.model.element.Modifier.PUBLIC;
  * A specialized version of service loader generation which is aimed at
  * executing in native images, where classloading is basically free.
  */
+@AOTModule(
+        id = NativeStaticServiceLoaderSourceGenerator.ID,
+        description = AbstractStaticServiceLoaderSourceGenerator.DESCRIPTION,
+        options = {
+                @Option(
+                        key = "service.types",
+                        description = "The list of service types to be scanned (comma separated)",
+                        sampleValue = "io.micronaut.Service1,io.micronaut.Service2"
+                ),
+                @Option(
+                        key = "serviceloading.rejected.impls",
+                        description = "A list of implementation types which shouldn't be included in the final application (comma separated)",
+                        sampleValue = "com.Misc,org.Bar"
+                )
+        },
+        enabledOn = Runtime.NATIVE,
+        subgenerators = { YamlPropertySourceGenerator.class }
+)
 public class NativeStaticServiceLoaderSourceGenerator extends AbstractStaticServiceLoaderSourceGenerator {
     public static final String ID = "serviceloading.native";
-
-    @Override
-    @NonNull
-    public String getId() {
-        return ID;
-    }
-
-    @Override
-    public boolean isEnabledOn(@NonNull Runtime runtime) {
-        return runtime == Runtime.NATIVE;
-    }
 
     protected final void generateFindAllMethod(Predicate<String> rejectedClasses,
                                                String serviceName,

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/PublishersSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/PublishersSourceGenerator.java
@@ -18,6 +18,7 @@ package io.micronaut.aot.std.sourcegen;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
+import io.micronaut.aot.core.AOTModule;
 import io.micronaut.aot.core.sourcegen.AbstractSourceGenerator;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.async.publisher.Publishers;
@@ -34,6 +35,10 @@ import java.util.stream.Collectors;
  * An optimizer which is responsible for determining what reactive
  * types are found at build time.
  */
+@AOTModule(
+        id = PublishersSourceGenerator.ID,
+        description = PublishersSourceGenerator.DESCRIPTION
+)
 public class PublishersSourceGenerator extends AbstractSourceGenerator {
     public static final String ID = "scan.reactive.types";
     public static final String DESCRIPTION = "Scans reactive types at build time instead of runtime";
@@ -42,22 +47,10 @@ public class PublishersSourceGenerator extends AbstractSourceGenerator {
     private List<String> knownSingleTypes;
     private List<String> knownCompletableTypes;
 
-    @Override
-    @NonNull
-    public Optional<String> getDescription() {
-        return Optional.of(DESCRIPTION);
-    }
-
     protected final void doInit() {
         knownReactiveTypes = typeNamesOf(Publishers.getKnownReactiveTypes());
         knownSingleTypes = typeNamesOf(Publishers.getKnownSingleTypes());
         knownCompletableTypes = typeNamesOf(Publishers.getKnownCompletableTypes());
-    }
-
-    @Override
-    @NonNull
-    public String getId() {
-        return ID;
     }
 
     @Override

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/SealedEnvironmentSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/SealedEnvironmentSourceGenerator.java
@@ -16,6 +16,7 @@
 package io.micronaut.aot.std.sourcegen;
 
 import com.squareup.javapoet.MethodSpec;
+import io.micronaut.aot.core.AOTModule;
 import io.micronaut.aot.core.sourcegen.AbstractSourceGenerator;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.optim.StaticOptimizations;
@@ -26,21 +27,13 @@ import java.util.Optional;
  * Generates the code used to enable environment variables and system
  * properties caching in Micronaut.
  */
+@AOTModule(
+        id = SealedEnvironmentSourceGenerator.ID,
+        description = SealedEnvironmentSourceGenerator.DESCRIPTION
+)
 public class SealedEnvironmentSourceGenerator extends AbstractSourceGenerator {
     public static final String ID = "sealed.environment";
     public static final String DESCRIPTION = "Seals environment property values: environment properties will be deemed immutable after application startup.";
-
-    @Override
-    @NonNull
-    public String getId() {
-        return ID;
-    }
-
-    @Override
-    @NonNull
-    public Optional<String> getDescription() {
-        return Optional.of(DESCRIPTION);
-    }
 
     @Override
     @NonNull

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/YamlPropertySourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/YamlPropertySourceGenerator.java
@@ -16,6 +16,7 @@
 package io.micronaut.aot.std.sourcegen;
 
 import com.squareup.javapoet.JavaFile;
+import io.micronaut.aot.core.AOTModule;
 import io.micronaut.aot.core.sourcegen.AbstractSourceGenerator;
 import io.micronaut.context.env.MapPropertySource;
 import io.micronaut.context.env.PropertySource;
@@ -37,6 +38,10 @@ import java.util.Optional;
  * with a static configuration.
  *
  */
+@AOTModule(
+        id = YamlPropertySourceGenerator.ID,
+        description = YamlPropertySourceGenerator.DESCRIPTION
+)
 public class YamlPropertySourceGenerator extends AbstractSourceGenerator {
     public static final String ID = "yaml.to.java.config";
     public static final String DESCRIPTION = "Converts YAML configuration files to Java configuration";
@@ -46,17 +51,6 @@ public class YamlPropertySourceGenerator extends AbstractSourceGenerator {
 
     public YamlPropertySourceGenerator(Collection<String> resources) {
         this.resources = resources;
-    }
-
-    @Override
-    @NonNull
-    public String getId() {
-        return ID;
-    }
-
-    @Override
-    public Optional<String> getDescription() {
-        return Optional.of(DESCRIPTION);
     }
 
     @Override

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/ConstantPropertySourcesSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/ConstantPropertySourcesSourceGeneratorTest.groovy
@@ -17,11 +17,12 @@ package io.micronaut.aot.std.sourcegen
 
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
+import io.micronaut.aot.core.AOTModule
 import io.micronaut.aot.core.AOTSourceGenerator
-import io.micronaut.aot.core.sourcegen.AbstractSourceGeneratorSpec
+import io.micronaut.aot.core.Option
 import io.micronaut.aot.core.sourcegen.AbstractSingleClassFileGenerator
+import io.micronaut.aot.core.sourcegen.AbstractSourceGeneratorSpec
 import io.micronaut.core.annotation.NonNull
-import org.jetbrains.annotations.NotNull
 
 import java.util.function.Predicate
 
@@ -51,6 +52,14 @@ class ConstantPropertySourcesSourceGeneratorTest extends AbstractSourceGenerator
         }
     }
 
+    @AOTModule(id = "loader", options = [
+            @Option(
+                    key = "service.types"
+            ),
+            @Option(
+                    key = "serviceloading.rejected.impls"
+            )
+    ])
     static class TestServiceLoaderGenerator extends AbstractStaticServiceLoaderSourceGenerator {
 
         @Override
@@ -60,14 +69,9 @@ class ConstantPropertySourcesSourceGeneratorTest extends AbstractSourceGenerator
                     (clazz, provider) -> clazz.getName()
             )
         }
-
-        @NotNull
-        @Override
-        String getId() {
-            "loader"
-        }
     }
 
+    @AOTModule(id = SubstituteGenerator.ID)
     class SubstituteGenerator extends AbstractSingleClassFileGenerator {
         private static final String ID = "internal.substitute.generator";
 
@@ -76,13 +80,6 @@ class ConstantPropertySourcesSourceGeneratorTest extends AbstractSourceGenerator
         protected JavaFile generate() {
             TypeSpec typeSpec = TypeSpec.classBuilder("Substitute").build()
             JavaFile.builder(packageName, typeSpec).build()
-        }
-
-        @NotNull
-        @Override
-        @NonNull
-        String getId() {
-            return ID;
         }
     }
 }

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGeneratorTest.groovy
@@ -6,7 +6,7 @@ import io.micronaut.aot.core.sourcegen.AbstractSourceGeneratorSpec
 class GraalVMOptimizationFeatureSourceGeneratorTest extends AbstractSourceGeneratorSpec {
     @Override
     AOTSourceGenerator newGenerator() {
-        props.put(GraalVMOptimizationFeatureSourceGenerator.OPTION.key, ['A', 'B', 'C'].join(','))
+        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, ['A', 'B', 'C'].join(','))
         new GraalVMOptimizationFeatureSourceGenerator()
     }
 

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGeneratorTest.groovy
@@ -25,7 +25,7 @@ class JitStaticServiceLoaderSourceGeneratorTest extends AbstractSourceGeneratorS
     }
 
     def "generates a service loader for a single service"() {
-        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES.key, TestService.name)
+        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, TestService.name)
 
         when:
         generate()
@@ -91,7 +91,7 @@ public class TestServiceFactory implements SoftServiceLoader.StaticServiceLoader
     }
 
     def "generates a service loader for a multiple implementations of a service"() {
-        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES.key, TestServiceWithMoreThanOneImpl.name)
+        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, TestServiceWithMoreThanOneImpl.name)
 
         when:
         generate()

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/KnownMissingTypesSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/KnownMissingTypesSourceGeneratorTest.groovy
@@ -21,7 +21,7 @@ import io.micronaut.aot.core.sourcegen.AbstractSourceGeneratorSpec
 class KnownMissingTypesSourceGeneratorTest extends AbstractSourceGeneratorSpec {
     @Override
     AOTSourceGenerator newGenerator() {
-        props.put(KnownMissingTypesSourceGenerator.OPTION.key,
+        props.put(KnownMissingTypesSourceGenerator.OPTION.key(),
                 [
                         'non.existing.ClassName',
                         AOTSourceGenerator.class.name,

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGeneratorTest.groovy
@@ -25,7 +25,7 @@ class NativeStaticServiceLoaderSourceGeneratorTest extends AbstractSourceGenerat
     }
 
     def "generates a service loader for a single service"() {
-        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES.key, TestService.name)
+        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, TestService.name)
 
         when:
         generate()
@@ -68,7 +68,7 @@ public class TestServiceFactory implements SoftServiceLoader.StaticServiceLoader
     }
 
     def "generates a service loader for a multiple implementations of a service"() {
-        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES.key, TestServiceWithMoreThanOneImpl.name)
+        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, TestServiceWithMoreThanOneImpl.name)
 
         when:
         generate()


### PR DESCRIPTION
The id, dependencies, options, subgenerators etc... of AOT modules,
which was static anyway, is now represented using annotations.
This removes suspicious instantiation of generators just for the
purpose of getting metadata.
