### PR TITLE
Remove `bomProperties` from `gradle.properties`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.0.0-M1
+projectVersion=1.0.0-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
 micronautVersion=3.2.0
 micronautTestVersion=2.3.7
@@ -15,8 +15,6 @@ developers=Graeme Rocher
 githubCoreBranch=3.2.x
 
 bomProperty=micronautAotVersion
-# If needed, set additional properties
-# bomProperties=hibernateVersion,tomcatJdbcVersion
 
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
The fact that it's commented out apparently causes trouble with
GitHub workflows.