### PR TITLE
Add optimization for deduce environment

### DIFF
--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -5,6 +5,7 @@ import io.micronaut.aot.core.AOTCodeGenerator
 import io.micronaut.aot.core.config.MetadataUtils
 import io.micronaut.aot.std.sourcegen.AbstractStaticServiceLoaderSourceGenerator
 import io.micronaut.aot.std.sourcegen.ConstantPropertySourcesSourceGenerator
+import io.micronaut.aot.std.sourcegen.DeduceEnvironmentSourceGenerator
 import io.micronaut.aot.std.sourcegen.EnvironmentPropertiesSourceGenerator
 import io.micronaut.aot.std.sourcegen.GraalVMOptimizationFeatureSourceGenerator
 import io.micronaut.aot.std.sourcegen.JitStaticServiceLoaderSourceGenerator
@@ -44,6 +45,7 @@ class CliTest extends Specification {
         Files.exists(configFile)
         def config = normalize(configFile.toFile().text)
         String expected = normalize([
+                [DeduceEnvironmentSourceGenerator.DESCRIPTION, "deduce.environment.enabled = true"],
                 runtime == 'native' ? [GraalVMOptimizationFeatureSourceGenerator.DESCRIPTION, "graalvm.config.enabled = true\n${toPropertiesSample(GraalVMOptimizationFeatureSourceGenerator)}"] : null,
                 [KnownMissingTypesSourceGenerator.DESCRIPTION, """known.missing.types.enabled = true
 ${toPropertiesSample(KnownMissingTypesSourceGenerator)}"""],

--- a/aot-core/src/main/java/io/micronaut/aot/core/codegen/AbstractCodeGenerator.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/codegen/AbstractCodeGenerator.java
@@ -51,7 +51,7 @@ public abstract class AbstractCodeGenerator implements AOTCodeGenerator {
 
     protected final void writeServiceFile(AOTContext context, Class<?> serviceType, String simpleServiceName) {
         context.registerGeneratedResource("META-INF/services/" + serviceType.getName(), serviceFile -> {
-            try (PrintWriter wrt = new PrintWriter(new FileWriter(serviceFile))) {
+            try (PrintWriter wrt = new PrintWriter(new FileWriter(serviceFile, true))) {
                 wrt.println(context.getPackageName() + "." + simpleServiceName);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/aot-core/src/main/java/io/micronaut/aot/core/context/ApplicationContextAnalyzer.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/context/ApplicationContextAnalyzer.java
@@ -16,6 +16,7 @@
 package io.micronaut.aot.core.context;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.DefaultBeanResolutionContext;
@@ -34,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -60,12 +62,28 @@ public final class ApplicationContextAnalyzer {
         return applicationContext.getEnvironment().getActiveNames();
     }
 
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+
     /**
      * Instantiates an application context analyzer.
      * @return an analyzer
      */
     public static ApplicationContextAnalyzer create() {
         return new ApplicationContextAnalyzer(ApplicationContext.builder().build());
+    }
+
+    /**
+     * Instantiates an application context analyzer with the ability to
+     * customize the application context.
+     * @param spec the spec to configure the application context
+     * @return the analyzer
+     */
+    public static ApplicationContextAnalyzer create(Consumer<? super ApplicationContextBuilder> spec) {
+        ApplicationContextBuilder builder = ApplicationContext.builder();
+        spec.accept(builder);
+        return new ApplicationContextAnalyzer(builder.build());
     }
 
     /**

--- a/aot-core/src/testFixtures/groovy/io/micronaut/aot/core/codegen/AbstractSourceGeneratorSpec.groovy
+++ b/aot-core/src/testFixtures/groovy/io/micronaut/aot/core/codegen/AbstractSourceGeneratorSpec.groovy
@@ -28,6 +28,7 @@ import spock.lang.Specification
 import spock.lang.TempDir
 
 import java.nio.file.Path
+import java.util.function.Function
 
 @CompileStatic
 abstract class AbstractSourceGeneratorSpec extends Specification {
@@ -200,24 +201,30 @@ abstract class AbstractSourceGeneratorSpec extends Specification {
         private final JavaFile javaFile
         private final String generatedSource
         private boolean checkedSources
+        private Function<String, String> normalizer = { it }
 
         JavaFileAssertions(JavaFile javaFile, String sources) {
             this.javaFile = javaFile
             this.generatedSource = normalize(sources)
         }
 
+        void withNormalizer(Function<String, String> normalizer) {
+            this.normalizer = normalizer
+        }
+
         void withSources(String expectedSource) {
             checkedSources = true
-            expectedSource = normalize(expectedSource)
-            if (generatedSource != expectedSource) {
+            expectedSource = normalizer.apply(normalize(expectedSource))
+            String actualSources = normalizer.apply(generatedSource)
+            if (actualSources != expectedSource) {
                 println("GENERATED")
                 println("=========")
-                println(generatedSource)
+                println(actualSources)
                 println("EXPECTED")
                 println("========")
                 println(expectedSource)
             }
-            assert generatedSource == expectedSource
+            assert actualSources == expectedSource
         }
 
         void containingSources(String expected) {

--- a/aot-core/src/testFixtures/groovy/io/micronaut/aot/core/codegen/AbstractSourceGeneratorSpec.groovy
+++ b/aot-core/src/testFixtures/groovy/io/micronaut/aot/core/codegen/AbstractSourceGeneratorSpec.groovy
@@ -23,6 +23,7 @@ import io.micronaut.aot.core.Configuration
 import io.micronaut.aot.core.config.DefaultConfiguration
 import io.micronaut.aot.core.context.ApplicationContextAnalyzer
 import io.micronaut.aot.core.context.DefaultSourceGenerationContext
+import io.micronaut.context.ApplicationContextBuilder
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -44,8 +45,13 @@ abstract class AbstractSourceGeneratorSpec extends Specification {
 
     def setup() {
         resourcesDir = testDirectory.resolve("resources")
-        context = new DefaultSourceGenerationContext(packageName, ApplicationContextAnalyzer.create(), config, resourcesDir)
+        context = new DefaultSourceGenerationContext(packageName, ApplicationContextAnalyzer.create { customizeContext(it) }, config, resourcesDir)
     }
+
+    protected void customizeContext(ApplicationContextBuilder builder) {
+
+    }
+
     abstract AOTCodeGenerator newGenerator()
 
     void generate() {

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGenerator.java
@@ -74,7 +74,7 @@ public class DeduceEnvironmentSourceGenerator extends AbstractCodeGenerator {
                 .addParameter(ApplicationContextBuilder.class, "builder");
         bodyBuilder.addStatement("builder.deduceEnvironment(false)");
         if (!environmentNames.isEmpty()) {
-            bodyBuilder.addStatement("builder.defaultEnvironments($L)", toQuotedStringList(environmentNames));
+            bodyBuilder.addStatement("builder.environments($L)", toQuotedStringList(environmentNames));
         }
         if (!packages.isEmpty()) {
             bodyBuilder.addStatement("builder.packages($L)", toQuotedStringList(packages));

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGenerator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aot.std.sourcegen;
+
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import io.micronaut.aot.core.AOTContext;
+import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.codegen.AbstractCodeGenerator;
+import io.micronaut.aot.core.context.ApplicationContextAnalyzer;
+import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.ApplicationContextConfiguration;
+import io.micronaut.context.ApplicationContextConfigurer;
+import io.micronaut.context.BeanContextConfiguration;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static javax.lang.model.element.Modifier.PUBLIC;
+
+/**
+ * This code generator is responsible for taking the result
+ * of the environment deduction, which is the set of active
+ * environment names and the package names, and inject is
+ * via a custom application context configurer. The resulting
+ * class will effectively disable environment deduction, so
+ * it will be done at build time instead of run time.
+ */
+@AOTModule(
+        id = DeduceEnvironmentSourceGenerator.ID,
+        description = DeduceEnvironmentSourceGenerator.DESCRIPTION
+)
+public class DeduceEnvironmentSourceGenerator extends AbstractCodeGenerator {
+    public static final String ID = "deduce.environment";
+    public static final String DESCRIPTION = "Deduces the environment at build time instead of runtime";
+    public static final String DEDUCED_ENVIRONMENT_CONFIGURER = "DeducedEnvironmentConfigurer";
+
+    @Override
+    public void generate(AOTContext context) {
+        ApplicationContextAnalyzer analyzer = context.getAnalyzer();
+        Set<String> environmentNames = analyzer.getEnvironmentNames();
+        BeanContextConfiguration contextConfiguration = analyzer.getApplicationContext().getContextConfiguration();
+        if (contextConfiguration instanceof ApplicationContextConfiguration) {
+            ((ApplicationContextConfiguration) contextConfiguration).getDeduceEnvironments().ifPresent(deduceEnvironments -> {
+                if (deduceEnvironments) {
+                    Collection<String> packages = analyzer.getApplicationContext().getEnvironment().getPackages();
+                    context.registerGeneratedSourceFile(
+                            context.javaFile(buildApplicationContextConfigurer(environmentNames, packages))
+                    );
+                    writeServiceFile(context, ApplicationContextConfigurer.class, DEDUCED_ENVIRONMENT_CONFIGURER);
+                }
+            });
+        }
+    }
+
+    private TypeSpec buildApplicationContextConfigurer(Set<String> environmentNames, Collection<String> packages) {
+        MethodSpec.Builder bodyBuilder = MethodSpec.methodBuilder("configure")
+                .addModifiers(PUBLIC)
+                .addAnnotation(Override.class)
+                .addParameter(ApplicationContextBuilder.class, "builder");
+        bodyBuilder.addStatement("builder.deduceEnvironment(false)");
+        if (!environmentNames.isEmpty()) {
+            bodyBuilder.addStatement("builder.defaultEnvironments($L)", toQuotedStringList(environmentNames));
+        }
+        if (!packages.isEmpty()) {
+            bodyBuilder.addStatement("builder.packages($L)", toQuotedStringList(packages));
+        }
+        return TypeSpec.classBuilder(DEDUCED_ENVIRONMENT_CONFIGURER)
+                .addSuperinterface(ApplicationContextConfigurer.class)
+                .addModifiers(PUBLIC)
+                .addMethod(bodyBuilder.build())
+                .addMethod(MethodSpec.methodBuilder("getOrder")
+                        .addModifiers(PUBLIC)
+                        .addAnnotation(Override.class)
+                        .returns(int.class)
+                        .addStatement("return LOWEST_PRECEDENCE")
+                        .build()
+                )
+                .build();
+    }
+
+    private static String toQuotedStringList(Collection<String> elements) {
+        return elements.stream().map(e -> '"' + e + '"').collect(Collectors.joining(", "));
+    }
+}

--- a/aot-std-optimizers/src/main/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator
+++ b/aot-std-optimizers/src/main/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator
@@ -7,3 +7,4 @@ io.micronaut.aot.std.sourcegen.ConstantPropertySourcesSourceGenerator
 io.micronaut.aot.std.sourcegen.SealedEnvironmentSourceGenerator
 io.micronaut.aot.std.sourcegen.LogbackConfigurationSourceGenerator
 io.micronaut.aot.std.sourcegen.GraalVMOptimizationFeatureSourceGenerator
+io.micronaut.aot.std.sourcegen.DeduceEnvironmentSourceGenerator

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGeneratorTest.groovy
@@ -24,7 +24,8 @@ class DeduceEnvironmentSourceGeneratorTest extends AbstractSourceGeneratorSpec {
             doesNotCreateInitializer()
             generatesMetaInfResource("services/io.micronaut.context.ApplicationContextConfigurer", 'io.micronaut.test.DeducedEnvironmentConfigurer')
             hasClass(DeduceEnvironmentSourceGenerator.DEDUCED_ENVIRONMENT_CONFIGURER) {
-               withSources """
+                withNormalizer { it.replaceAll('(?m)"[a-z.]+reflect[a-z.]*"', "<snip>") }
+                withSources """
 package io.micronaut.test;
 
 import io.micronaut.context.ApplicationContextBuilder;
@@ -36,7 +37,7 @@ public class DeducedEnvironmentConfigurer implements ApplicationContextConfigure
   public void configure(ApplicationContextBuilder builder) {
     builder.deduceEnvironment(false);
     builder.environments("test");
-    builder.packages("jdk.internal.reflect");
+    builder.packages(<snip>);
   }
 
   @Override

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGeneratorTest.groovy
@@ -35,7 +35,7 @@ public class DeducedEnvironmentConfigurer implements ApplicationContextConfigure
   @Override
   public void configure(ApplicationContextBuilder builder) {
     builder.deduceEnvironment(false);
-    builder.defaultEnvironments("test");
+    builder.environments("test");
     builder.packages("jdk.internal.reflect");
   }
 

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGeneratorTest.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.aot.std.sourcegen
+
+import io.micronaut.aot.core.AOTCodeGenerator
+import io.micronaut.aot.core.codegen.AbstractSourceGeneratorSpec
+import io.micronaut.context.ApplicationContextBuilder
+
+class DeduceEnvironmentSourceGeneratorTest extends AbstractSourceGeneratorSpec {
+    @Override
+    AOTCodeGenerator newGenerator() {
+        new DeduceEnvironmentSourceGenerator()
+    }
+
+    @Override
+    protected void customizeContext(ApplicationContextBuilder builder) {
+        builder.deduceEnvironment(true)
+    }
+
+    def "generates a context configurer which disables deduce environment"() {
+        when:
+        generate()
+
+        then:
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            generatesMetaInfResource("services/io.micronaut.context.ApplicationContextConfigurer", 'io.micronaut.test.DeducedEnvironmentConfigurer')
+            hasClass(DeduceEnvironmentSourceGenerator.DEDUCED_ENVIRONMENT_CONFIGURER) {
+               withSources """
+package io.micronaut.test;
+
+import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.ApplicationContextConfigurer;
+import java.lang.Override;
+
+public class DeducedEnvironmentConfigurer implements ApplicationContextConfigurer {
+  @Override
+  public void configure(ApplicationContextBuilder builder) {
+    builder.deduceEnvironment(false);
+    builder.defaultEnvironments("test");
+    builder.packages("jdk.internal.reflect");
+  }
+
+  @Override
+  public int getOrder() {
+    return LOWEST_PRECEDENCE;
+  }
+}
+"""
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new optimization: if `deduceEnvironment(true)`
is set, then we will get the result of the analysis, which is the list
of environment names and packages, and inject them directly in a
generated application context configurer, which itself disables
`deduceEnvironment`.

This means that the deployment environment must be the same as the
build environment.