### PR TITLE
Fix incorrect test fixtures capabilities

### DIFF
--- a/aot-std-optimizers/build.gradle.kts
+++ b/aot-std-optimizers/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     compileOnlyApi(mn.micronaut.context)
     compileOnlyApi(mn.micronaut.core.reactive)
 
-    implementation(projects.aotCore)
+    compileOnlyApi(projects.aotCore)
     compileOnly(mn.logback)
 
     testImplementation(testFixtures(projects.aotCore))

--- a/build-logic/src/main/groovy/io.micronaut.build.internal.aot-module.gradle
+++ b/build-logic/src/main/groovy/io.micronaut.build.internal.aot-module.gradle
@@ -28,3 +28,12 @@ micronautBuild {
     enableProcessing = false
     enableBom = false
 }
+
+pluginManager.withPlugin("java-test-fixtures") {
+    // Workaround for incorrect capabilities published because of the renaming
+    // of the modules at publication time
+    ["testFixturesApiElements", "testFixturesRuntimeElements"].each {
+        def outgoing = configurations.getByName(it).outgoing
+        outgoing.capability("$group:micronaut-${project.name}-test-fixtures:$projectVersion")
+    }
+}


### PR DESCRIPTION
This commit fixes the capabilities published for test fixtures,
preventing the use of the `testFixtures(...)` dependency notation.
This is going to be useful once we have an internal plugin to
create AOT modules.