### PR TITLE
Make sure that disabled configurations are honored

### DIFF
--- a/aot-core/src/main/java/io/micronaut/aot/core/context/ApplicationContextAnalyzer.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/context/ApplicationContextAnalyzer.java
@@ -24,6 +24,7 @@ import io.micronaut.context.Qualifier;
 import io.micronaut.context.RequiresCondition;
 import io.micronaut.context.condition.ConditionContext;
 import io.micronaut.context.condition.Failure;
+import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.type.Argument;
@@ -56,6 +57,8 @@ public final class ApplicationContextAnalyzer {
 
     private ApplicationContextAnalyzer(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
+//        Environment environment = this.applicationContext.getEnvironment();
+//        environment.getPropertySourceLoaders().forEach(loader -> loader.load(environment));
     }
 
     public Set<String> getEnvironmentNames() {
@@ -71,7 +74,7 @@ public final class ApplicationContextAnalyzer {
      * @return an analyzer
      */
     public static ApplicationContextAnalyzer create() {
-        return new ApplicationContextAnalyzer(ApplicationContext.builder().build());
+        return create(spec -> { });
     }
 
     /**
@@ -83,7 +86,10 @@ public final class ApplicationContextAnalyzer {
     public static ApplicationContextAnalyzer create(Consumer<? super ApplicationContextBuilder> spec) {
         ApplicationContextBuilder builder = ApplicationContext.builder();
         spec.accept(builder);
-        return new ApplicationContextAnalyzer(builder.build());
+        ApplicationContext context = builder.build();
+        Environment environment = context.getEnvironment();
+        environment.start();
+        return new ApplicationContextAnalyzer(context);
     }
 
     /**

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGenerator.java
@@ -27,11 +27,11 @@ import io.micronaut.aot.core.Runtime;
 import io.micronaut.core.io.service.SoftServiceLoader;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static javax.lang.model.element.Modifier.FINAL;
@@ -64,15 +64,14 @@ import static javax.lang.model.element.Modifier.STATIC;
 public class JitStaticServiceLoaderSourceGenerator extends AbstractStaticServiceLoaderSourceGenerator {
     public static final String ID = "serviceloading.jit";
 
-    protected final void generateFindAllMethod(Predicate<String> rejectedClasses,
+    protected final void generateFindAllMethod(Stream<Class<?>> serviceClasses,
                                                String serviceName,
                                                Class<?> serviceType,
                                                TypeSpec.Builder factory) {
-        List<String> initializers = collectServiceImplementations(
-                serviceName,
-                (clazz, provider) -> clazz.getName()
-        );
-        Collections.sort(initializers);
+        List<String> initializers = serviceClasses
+                .map(Class::getName)
+                .sorted()
+                .collect(Collectors.toList());
         ParameterizedTypeName staticDefinitionType = ParameterizedTypeName.get(SoftServiceLoader.StaticDefinition.class, serviceType);
         ParameterizedTypeName serviceTypeClassType = ParameterizedTypeName.get(Class.class, serviceType);
 

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/ConstantPropertySourcesSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/ConstantPropertySourcesSourceGeneratorTest.groovy
@@ -24,7 +24,7 @@ import io.micronaut.aot.core.codegen.AbstractSingleClassFileGenerator
 import io.micronaut.aot.core.codegen.AbstractSourceGeneratorSpec
 import io.micronaut.core.annotation.NonNull
 
-import java.util.function.Predicate
+import java.util.stream.Stream
 
 class ConstantPropertySourcesSourceGeneratorTest extends AbstractSourceGeneratorSpec {
     private final Map<String, AbstractSingleClassFileGenerator> substitutions = [:]
@@ -61,13 +61,12 @@ class ConstantPropertySourcesSourceGeneratorTest extends AbstractSourceGenerator
             )
     ])
     static class TestServiceLoaderGenerator extends AbstractStaticServiceLoaderSourceGenerator {
-
         @Override
-        protected void generateFindAllMethod(Predicate<String> rejectedClasses, String serviceName, Class<?> serviceType, TypeSpec.Builder factory) {
-            collectServiceImplementations(
-                    serviceName,
-                    (clazz, provider) -> clazz.getName()
-            )
+        protected void generateFindAllMethod(Stream<Class<?>> serviceClasses,
+                                             String serviceName,
+                                             Class<?> serviceType,
+                                             TypeSpec.Builder factory) {
+
         }
     }
 


### PR DESCRIPTION
This commit fixes how service loading filters beans. Before the change it was
done service type by service type, ignoring interactions between them. In
practice, a Micronaut `BeanConfiguration` (like an annotated package) may
disable a bean definition (reference), so we cannot generate the list of
services immediately: we have to finish loading all service types, then we
need to perform a check similar to the one done in Micronaut itself, which
filters out beans which are disabled by a specific configuration.

Fixes #25