### PR TITLE
Rename sealed environment -> cached environment

### DIFF
--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -12,7 +12,7 @@ import io.micronaut.aot.std.sourcegen.JitStaticServiceLoaderSourceGenerator
 import io.micronaut.aot.std.sourcegen.KnownMissingTypesSourceGenerator
 import io.micronaut.aot.std.sourcegen.LogbackConfigurationSourceGenerator
 import io.micronaut.aot.std.sourcegen.PublishersSourceGenerator
-import io.micronaut.aot.std.sourcegen.SealedEnvironmentSourceGenerator
+import io.micronaut.aot.std.sourcegen.CachedEnvironmentSourceGenerator
 import io.micronaut.aot.std.sourcegen.YamlPropertySourceGenerator
 import spock.lang.Specification
 import spock.lang.TempDir
@@ -45,6 +45,7 @@ class CliTest extends Specification {
         Files.exists(configFile)
         def config = normalize(configFile.toFile().text)
         String expected = normalize([
+                [CachedEnvironmentSourceGenerator.DESCRIPTION, 'cached.environment.enabled = true'],
                 [DeduceEnvironmentSourceGenerator.DESCRIPTION, "deduce.environment.enabled = true"],
                 runtime == 'native' ? [GraalVMOptimizationFeatureSourceGenerator.DESCRIPTION, "graalvm.config.enabled = true\n${toPropertiesSample(GraalVMOptimizationFeatureSourceGenerator)}"] : null,
                 [KnownMissingTypesSourceGenerator.DESCRIPTION, """known.missing.types.enabled = true
@@ -52,7 +53,6 @@ ${toPropertiesSample(KnownMissingTypesSourceGenerator)}"""],
                 [LogbackConfigurationSourceGenerator.DESCRIPTION, 'logback.xml.to.java.enabled = true'],
                 [EnvironmentPropertiesSourceGenerator.DESCRIPTION, 'precompute.environment.properties.enabled = true'],
                 [PublishersSourceGenerator.DESCRIPTION, 'scan.reactive.types.enabled = true'],
-                [SealedEnvironmentSourceGenerator.DESCRIPTION, 'sealed.environment.enabled = true'],
                 [AbstractStaticServiceLoaderSourceGenerator.DESCRIPTION, """serviceloading.${runtime}.enabled = true
 ${toPropertiesSample(JitStaticServiceLoaderSourceGenerator, AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES)}
 ${toPropertiesSample(JitStaticServiceLoaderSourceGenerator, AbstractStaticServiceLoaderSourceGenerator.REJECTED_CLASSES)}"""],

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/CachedEnvironmentSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/CachedEnvironmentSourceGenerator.java
@@ -26,12 +26,12 @@ import io.micronaut.core.optim.StaticOptimizations;
  * properties caching in Micronaut.
  */
 @AOTModule(
-        id = SealedEnvironmentSourceGenerator.ID,
-        description = SealedEnvironmentSourceGenerator.DESCRIPTION
+        id = CachedEnvironmentSourceGenerator.ID,
+        description = CachedEnvironmentSourceGenerator.DESCRIPTION
 )
-public class SealedEnvironmentSourceGenerator extends AbstractCodeGenerator {
-    public static final String ID = "sealed.environment";
-    public static final String DESCRIPTION = "Seals environment property values: environment properties will be deemed immutable after application startup.";
+public class CachedEnvironmentSourceGenerator extends AbstractCodeGenerator {
+    public static final String ID = "cached.environment";
+    public static final String DESCRIPTION = "Caches environment property values: environment properties will be deemed immutable after application startup.";
 
     @Override
     public void generate(@NonNull AOTContext context) {

--- a/aot-std-optimizers/src/main/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator
+++ b/aot-std-optimizers/src/main/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator
@@ -4,7 +4,7 @@ io.micronaut.aot.std.sourcegen.NativeStaticServiceLoaderSourceGenerator
 io.micronaut.aot.std.sourcegen.EnvironmentPropertiesSourceGenerator
 io.micronaut.aot.std.sourcegen.PublishersSourceGenerator
 io.micronaut.aot.std.sourcegen.ConstantPropertySourcesSourceGenerator
-io.micronaut.aot.std.sourcegen.SealedEnvironmentSourceGenerator
+io.micronaut.aot.std.sourcegen.CachedEnvironmentSourceGenerator
 io.micronaut.aot.std.sourcegen.LogbackConfigurationSourceGenerator
 io.micronaut.aot.std.sourcegen.GraalVMOptimizationFeatureSourceGenerator
 io.micronaut.aot.std.sourcegen.DeduceEnvironmentSourceGenerator

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/CachedEnvironmentSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/CachedEnvironmentSourceGeneratorTest.groovy
@@ -18,10 +18,10 @@ package io.micronaut.aot.std.sourcegen
 import io.micronaut.aot.core.AOTCodeGenerator
 import io.micronaut.aot.core.codegen.AbstractSourceGeneratorSpec
 
-class SealedEnvironmentSourceGeneratorTest extends AbstractSourceGeneratorSpec {
+class CachedEnvironmentSourceGeneratorTest extends AbstractSourceGeneratorSpec {
     @Override
     AOTCodeGenerator newGenerator() {
-        new SealedEnvironmentSourceGenerator()
+        new CachedEnvironmentSourceGenerator()
     }
 
     def "generates code to enable environment caching"() {


### PR DESCRIPTION
The optimization is effectively a _runtime_ optimization, in the sense
that it doesn't take what is at build time as the runtime values.

Fixes #32

This will also require changes to the Gradle plugin for consistency.