### PR TITLE
Add an option to configure the list of possible environments

### DIFF
--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -7,6 +7,7 @@ import io.micronaut.aot.std.sourcegen.AbstractStaticServiceLoaderSourceGenerator
 import io.micronaut.aot.std.sourcegen.ConstantPropertySourcesSourceGenerator
 import io.micronaut.aot.std.sourcegen.DeduceEnvironmentSourceGenerator
 import io.micronaut.aot.std.sourcegen.EnvironmentPropertiesSourceGenerator
+import io.micronaut.aot.std.sourcegen.Environments
 import io.micronaut.aot.std.sourcegen.GraalVMOptimizationFeatureSourceGenerator
 import io.micronaut.aot.std.sourcegen.JitStaticServiceLoaderSourceGenerator
 import io.micronaut.aot.std.sourcegen.KnownMissingTypesSourceGenerator
@@ -56,7 +57,8 @@ ${toPropertiesSample(KnownMissingTypesSourceGenerator)}"""],
                 [AbstractStaticServiceLoaderSourceGenerator.DESCRIPTION, """serviceloading.${runtime}.enabled = true
 ${toPropertiesSample(JitStaticServiceLoaderSourceGenerator, AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES)}
 ${toPropertiesSample(JitStaticServiceLoaderSourceGenerator, AbstractStaticServiceLoaderSourceGenerator.REJECTED_CLASSES)}
-${toPropertiesSample(JitStaticServiceLoaderSourceGenerator, AbstractStaticServiceLoaderSourceGenerator.FORCE_INCLUDE)}"""],
+${toPropertiesSample(JitStaticServiceLoaderSourceGenerator, AbstractStaticServiceLoaderSourceGenerator.FORCE_INCLUDE)}
+${toPropertiesSample(JitStaticServiceLoaderSourceGenerator, Environments.POSSIBLE_ENVIRONMENTS_NAMES)}"""],
                 [YamlPropertySourceGenerator.DESCRIPTION, 'yaml.to.java.config.enabled = true'],
                 [ConstantPropertySourcesSourceGenerator.DESCRIPTION, "sealed.property.source.enabled = true"],
         ].findAll().collect { desc, c -> """# $desc

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/AbstractStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/AbstractStaticServiceLoaderSourceGenerator.java
@@ -93,6 +93,11 @@ public abstract class AbstractStaticServiceLoaderSourceGenerator extends Abstrac
                     .stream()
                     .map(env -> "application-" + env)
                     .forEach(resourceNames::add);
+            context.getConfiguration().stringList(Environments.POSSIBLE_ENVIRONMENTS_NAMES)
+                    .stream()
+                    .filter(env -> !"default".equals(env))
+                    .map(env -> "application-" + env)
+                    .forEach(resourceNames::add);
             substitutions = new HashMap<>();
             if (context.getConfiguration().isFeatureEnabled(YamlPropertySourceGenerator.ID)) {
                 YamlPropertySourceGenerator yaml = new YamlPropertySourceGenerator(resourceNames);

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGenerator.java
@@ -74,7 +74,7 @@ public class DeduceEnvironmentSourceGenerator extends AbstractCodeGenerator {
                 .addParameter(ApplicationContextBuilder.class, "builder");
         bodyBuilder.addStatement("builder.deduceEnvironment(false)");
         if (!environmentNames.isEmpty()) {
-            bodyBuilder.addStatement("builder.environments($L)", toQuotedStringList(environmentNames));
+            bodyBuilder.addStatement("builder.defaultEnvironments($L)", toQuotedStringList(environmentNames));
         }
         if (!packages.isEmpty()) {
             bodyBuilder.addStatement("builder.packages($L)", toQuotedStringList(packages));

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/Environments.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/Environments.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aot.std.sourcegen;
+
+/**
+ * Constants used for configuration of environments.
+ */
+public final class Environments {
+    public static final String POSSIBLE_ENVIRONMENTS_NAMES = "possible.environments";
+    public static final String POSSIBLE_ENVIRONMENTS_DESCRIPTION = "The list of environment names that this application can possibly use at runtime.";
+    public static final String POSSIBLE_ENVIRONMENTS_SAMPLE = "dev,prod,aws,gcs";
+}

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGenerator.java
@@ -61,6 +61,11 @@ import static javax.lang.model.element.Modifier.STATIC;
                         key = "serviceloading.force.include.impls",
                         description = "A list of implementation types to include even if they don't match bean requirements (comma separated)",
                         sampleValue = "com.Misc,org.Bar"
+                ),
+                @Option(
+                        key = Environments.POSSIBLE_ENVIRONMENTS_NAMES,
+                        description = Environments.POSSIBLE_ENVIRONMENTS_DESCRIPTION,
+                        sampleValue = Environments.POSSIBLE_ENVIRONMENTS_SAMPLE
                 )
         },
         enabledOn = Runtime.JIT,

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGenerator.java
@@ -60,6 +60,11 @@ import static javax.lang.model.element.Modifier.PUBLIC;
                         key = "serviceloading.force.include.impls",
                         description = "A list of implementation types to include even if they don't match bean requirements (comma separated)",
                         sampleValue = "com.Misc,org.Bar"
+                ),
+                @Option(
+                        key = Environments.POSSIBLE_ENVIRONMENTS_NAMES,
+                        description = Environments.POSSIBLE_ENVIRONMENTS_DESCRIPTION,
+                        sampleValue = Environments.POSSIBLE_ENVIRONMENTS_SAMPLE
                 )
         },
         enabledOn = Runtime.NATIVE,

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/ConstantPropertySourcesSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/ConstantPropertySourcesSourceGeneratorTest.groovy
@@ -61,6 +61,11 @@ class ConstantPropertySourcesSourceGeneratorTest extends AbstractSourceGenerator
             ),
             @Option(
                     key = "serviceloading.force.include.impls"
+            ),
+            @Option(
+                    key = Environments.POSSIBLE_ENVIRONMENTS_NAMES,
+                    description = Environments.POSSIBLE_ENVIRONMENTS_DESCRIPTION,
+                    sampleValue = Environments.POSSIBLE_ENVIRONMENTS_SAMPLE
             )
     ])
     static class TestServiceLoaderGenerator extends AbstractStaticServiceLoaderSourceGenerator {

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGeneratorTest.groovy
@@ -36,7 +36,7 @@ public class DeducedEnvironmentConfigurer implements ApplicationContextConfigure
   @Override
   public void configure(ApplicationContextBuilder builder) {
     builder.deduceEnvironment(false);
-    builder.environments("test");
+    builder.defaultEnvironments("test");
     builder.packages(<snip>);
   }
 


### PR DESCRIPTION
This commit introduces a new configuration option (possible.environments)
which lists the names of environments which can be seen. This makes it
possible to load environments for optimized applications too, as long
as the bean requirements do not check for specific environments.

Without this, the only environments which are "seen" by AOT are the
environments which are active when analyzing the context. It means that
it cannot, for example, convert to yaml configuration files which are
for other environments.

By default, if you specify nothing, then the optimizations ARE using
the active environments. If you do specify the option, then it means
that you want to enable the user to specify different environments
at runtime, for example using the `MICRONAUT_ENVIRONMENTS` variable,
even for optimized applications.

This will require a change to Micronaut Core, which currently loads
_all_ configured environments statically as soon as a file is
converted to a constant property source (which is arguably a bug).

Closes #36