### PR TITLE
Add an option to "force" a particular environment

### DIFF
--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -7,7 +7,7 @@ import io.micronaut.aot.std.sourcegen.AbstractStaticServiceLoaderSourceGenerator
 import io.micronaut.aot.std.sourcegen.ConstantPropertySourcesSourceGenerator
 import io.micronaut.aot.std.sourcegen.DeduceEnvironmentSourceGenerator
 import io.micronaut.aot.std.sourcegen.EnvironmentPropertiesSourceGenerator
-import io.micronaut.aot.std.sourcegen.Environments
+import io.micronaut.aot.core.Environments
 import io.micronaut.aot.std.sourcegen.GraalVMOptimizationFeatureSourceGenerator
 import io.micronaut.aot.std.sourcegen.JitStaticServiceLoaderSourceGenerator
 import io.micronaut.aot.std.sourcegen.KnownMissingTypesSourceGenerator
@@ -45,7 +45,8 @@ class CliTest extends Specification {
         then:
         Files.exists(configFile)
         def config = normalize(configFile.toFile().text)
-        String expected = normalize([
+
+        def generatedDocs = [
                 [CachedEnvironmentSourceGenerator.DESCRIPTION, 'cached.environment.enabled = true'],
                 [DeduceEnvironmentSourceGenerator.DESCRIPTION, "deduce.environment.enabled = true"],
                 runtime == 'native' ? [GraalVMOptimizationFeatureSourceGenerator.DESCRIPTION, "graalvm.config.enabled = true\n${toPropertiesSample(GraalVMOptimizationFeatureSourceGenerator)}"] : null,
@@ -61,9 +62,16 @@ ${toPropertiesSample(JitStaticServiceLoaderSourceGenerator, AbstractStaticServic
 ${toPropertiesSample(JitStaticServiceLoaderSourceGenerator, Environments.POSSIBLE_ENVIRONMENTS_NAMES)}"""],
                 [YamlPropertySourceGenerator.DESCRIPTION, 'yaml.to.java.config.enabled = true'],
                 [ConstantPropertySourcesSourceGenerator.DESCRIPTION, "sealed.property.source.enabled = true"],
-        ].findAll().collect { desc, c -> """# $desc
+        ].findAll().collect { desc, c ->
+            """# $desc
 $c
-""" }.join("\n").trim())
+"""
+        }.join("\n").trim()
+        String expected = normalize """$generatedDocs
+
+# ${Environments.TARGET_ENVIRONMENTS_DESCRIPTION}
+${Environments.TARGET_ENVIRONMENTS_NAMES} = ${Environments.TARGET_ENVIRONMENTS_SAMPLE}
+""".trim()
 
         println config
         config == expected

--- a/aot-core/src/main/java/io/micronaut/aot/core/Configuration.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/Configuration.java
@@ -31,6 +31,14 @@ import java.util.stream.Collectors;
  */
 public interface Configuration {
     /**
+     * Returns true if the configuration contains an entry
+     * for the specified key.
+     * @param key the key to look for
+     * @return true if the configuration contains an entry for the key
+     */
+    boolean containsKey(String key);
+
+    /**
      * Returns the value of the configuration for the requested
      * key or fails if not available.
      *

--- a/aot-core/src/main/java/io/micronaut/aot/core/Environments.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/Environments.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aot.std.sourcegen;
+package io.micronaut.aot.core;
 
 /**
  * Constants used for configuration of environments.
@@ -22,4 +22,9 @@ public final class Environments {
     public static final String POSSIBLE_ENVIRONMENTS_NAMES = "possible.environments";
     public static final String POSSIBLE_ENVIRONMENTS_DESCRIPTION = "The list of environment names that this application can possibly use at runtime.";
     public static final String POSSIBLE_ENVIRONMENTS_SAMPLE = "dev,prod,aws,gcs";
+
+    public static final String TARGET_ENVIRONMENTS_NAMES = "target.environments";
+    public static final String TARGET_ENVIRONMENTS_DESCRIPTION = "Configures the active environments when the AOT dynamic analysis is performed.";
+    public static final String TARGET_ENVIRONMENTS_SAMPLE = "lambda";
+
 }

--- a/aot-core/src/main/java/io/micronaut/aot/core/config/DefaultConfiguration.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/config/DefaultConfiguration.java
@@ -35,6 +35,18 @@ public class DefaultConfiguration implements Configuration {
         this.config = backingProperties;
     }
 
+    /**
+     * Returns true if the configuration contains an entry
+     * for the specified key.
+     *
+     * @param key the key to look for
+     * @return true if the configuration contains an entry for the key
+     */
+    @Override
+    public boolean containsKey(String key) {
+        return config.containsKey(key);
+    }
+
     @NonNull
     @Override
     public String mandatoryValue(String key) {

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/AbstractStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/AbstractStaticServiceLoaderSourceGenerator.java
@@ -22,6 +22,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.WildcardTypeName;
 import io.micronaut.aot.core.AOTContext;
+import io.micronaut.aot.core.Environments;
 import io.micronaut.aot.core.codegen.AbstractCodeGenerator;
 import io.micronaut.aot.core.codegen.DelegatingSourceGenerationContext;
 import io.micronaut.aot.core.config.MetadataUtils;

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGenerator.java
@@ -22,6 +22,7 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.Environments;
 import io.micronaut.aot.core.Option;
 import io.micronaut.aot.core.Runtime;
 import io.micronaut.core.io.service.SoftServiceLoader;

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGenerator.java
@@ -21,6 +21,7 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.Environments;
 import io.micronaut.aot.core.Option;
 import io.micronaut.aot.core.Runtime;
 import io.micronaut.core.io.service.SoftServiceLoader;

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/ConstantPropertySourcesSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/ConstantPropertySourcesSourceGeneratorTest.groovy
@@ -19,6 +19,7 @@ import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
 import io.micronaut.aot.core.AOTModule
 import io.micronaut.aot.core.AOTCodeGenerator
+import io.micronaut.aot.core.Environments
 import io.micronaut.aot.core.Option
 import io.micronaut.aot.core.codegen.AbstractSingleClassFileGenerator
 import io.micronaut.aot.core.codegen.AbstractSourceGeneratorSpec


### PR DESCRIPTION
Currently the AOT analysis can be configured to tell the list of
_possible_ environments, for example so that we can convert _all_
configuration files to Java and not just the currently detected
environment. However, it doesn't let the user specify a particular
target environment for analysis. This may be useful when the
environement where the analysis is performed is known to be different
from the deployment environment. In particular, because the analysis
will be done based on bean requirements, having environments
forcefully activated can enable some beans which would otherwise
have been eliminated from the analysis.

To do this the user needs to configure the following property:

`target.environments=lambda`