### PR TITLE
Fix GraalVM feature generation

### DIFF
--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGenerator.java
@@ -61,13 +61,15 @@ public class GraalVMOptimizationFeatureSourceGenerator extends AbstractCodeGener
             try (PrintWriter wrt = new PrintWriter(new FileWriter(propertiesFile))) {
                 wrt.print("Args=");
                 wrt.println("--initialize-at-build-time=" + context.getPackageName() + "." + ApplicationContextConfigurerGenerator.CUSTOMIZER_CLASS_NAME + NEXT_LINE);
-                for (int i = 0; i < serviceTypes.size(); i++) {
-                    String serviceType = serviceTypes.get(i);
-                    wrt.print("     -H:ServiceLoaderFeatureExcludeServices=" + serviceType);
-                    if (i < serviceTypes.size() - 1) {
-                        wrt.println(NEXT_LINE);
-                    } else {
-                        wrt.println();
+                if (context.getConfiguration().isFeatureEnabled(NativeStaticServiceLoaderSourceGenerator.ID)) {
+                    for (int i = 0; i < serviceTypes.size(); i++) {
+                        String serviceType = serviceTypes.get(i);
+                        wrt.print("     -H:ServiceLoaderFeatureExcludeServices=" + serviceType);
+                        if (i < serviceTypes.size() - 1) {
+                            wrt.println(NEXT_LINE);
+                        } else {
+                            wrt.println();
+                        }
                     }
                 }
                 wrt.println();

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGeneratorTest.groovy
@@ -19,6 +19,20 @@ class GraalVMOptimizationFeatureSourceGeneratorTest extends AbstractSourceGenera
             doesNotCreateInitializer()
             generatesMetaInfResource("native-image/$packageName/native-image.properties", """
 Args=--initialize-at-build-time=io.micronaut.test.AOTApplicationContextConfigurer \\
+""")
+        }
+    }
+
+    def "generates a feature file excluding service loading"() {
+        when:
+        props.put("${NativeStaticServiceLoaderSourceGenerator.ID}.enabled".toString(), "true")
+        generate()
+
+        then:
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            generatesMetaInfResource("native-image/$packageName/native-image.properties", """
+Args=--initialize-at-build-time=io.micronaut.test.AOTApplicationContextConfigurer \\
      -H:ServiceLoaderFeatureExcludeServices=A \\
      -H:ServiceLoaderFeatureExcludeServices=B \\
      -H:ServiceLoaderFeatureExcludeServices=C


### PR DESCRIPTION
This commit fixes a bug in the GraalVM feature generation: the exclusion
of service loading should only be done if the native service loading
optimization is enabled.