### PR TITLE
Remove optimizer classpath

### DIFF
--- a/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
+++ b/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
@@ -30,7 +30,6 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -45,8 +44,6 @@ import java.util.stream.Collectors;
         versionProvider = VersionProvider.class,
         description = "Generates classes for Micronaut AOT (build time optimizations)")
 public class Main implements Runnable, ConfigKeys {
-    @Option(names = {"--optimizer-classpath", "-ocp"}, description = "The Micronaut AOT classpath", required = true)
-    private String aotClasspathString;
 
     @Option(names = {"--classpath", "-cp"}, description = "The Micronaut application classpath", required = true)
     private String classpathString;
@@ -65,9 +62,7 @@ public class Main implements Runnable, ConfigKeys {
 
     @Override
     public void run() {
-        List<URL> classpath = new ArrayList<>();
-        classpath.addAll(toURLs(aotClasspathString));
-        classpath.addAll(toURLs(classpathString));
+        List<URL> classpath = toURLs(classpathString);
         Properties props = new Properties();
         if (config.exists()) {
             try (InputStreamReader reader = new InputStreamReader(new FileInputStream(config))) {

--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -35,7 +35,6 @@ class CliTest extends Specification {
         isolate {
             Main.execute(
                     '--classpath', classpath,
-                    '--optimizer-classpath', classpath,
                     '--runtime', runtime,
                     '--package', 'dummy',
                     '--config', configFile.toString()


### PR DESCRIPTION
In practice, the AOT optimizer classpath and the application classpath
are mixed. The fact of putting the AOT optimizer classpath in a separate
argument creates confusion and can cause problems (if the Micronaut
version of AOT is different from the one under test).

Therefore, this commit removes the optimizer classpath option and uses
a single option.