### PR TITLE
Implement logback.xml to Java conversion

### DIFF
--- a/aot-core/build.gradle.kts
+++ b/aot-core/build.gradle.kts
@@ -37,8 +37,6 @@ dependencies {
 
     api(libs.javapoet)
 
-    compileOnly(mn.logback)
-
     testFixturesImplementation(libs.javapoet)
     testFixturesApi(mn.spock)
 

--- a/aot-std-optimizers/build.gradle.kts
+++ b/aot-std-optimizers/build.gradle.kts
@@ -27,11 +27,19 @@ dependencies {
     compileOnlyApi(mn.micronaut.core.reactive)
 
     compileOnlyApi(projects.aotCore)
-    compileOnly(mn.logback)
+    compileOnly(mn.logback) {
+        version {
+            require("1.3.0-alpha12")
+        }
+    }
 
     testImplementation(testFixtures(projects.aotCore))
     testImplementation(mn.micronaut.context)
     testImplementation(mn.micronaut.core.reactive)
     testCompileOnly(projects.aotCore)
-
+    testImplementation(mn.logback) {
+        version {
+            require("1.3.0-alpha12")
+        }
+    }
 }

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGenerator.java
@@ -17,26 +17,46 @@ package io.micronaut.aot.std.sourcegen;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.model.ConfigurationModel;
+import ch.qos.logback.classic.model.LoggerModel;
+import ch.qos.logback.classic.model.RootLoggerModel;
 import ch.qos.logback.classic.spi.Configurator;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.Context;
+import ch.qos.logback.core.joran.spi.JoranException;
+import ch.qos.logback.core.joran.util.beans.BeanDescription;
+import ch.qos.logback.core.joran.util.beans.BeanDescriptionCache;
+import ch.qos.logback.core.model.AppenderModel;
+import ch.qos.logback.core.model.AppenderRefModel;
+import ch.qos.logback.core.model.ComponentModel;
+import ch.qos.logback.core.model.ImplicitModel;
+import ch.qos.logback.core.model.Model;
+import ch.qos.logback.core.model.NamedComponentModel;
+import ch.qos.logback.core.spi.ContextAware;
+import ch.qos.logback.core.spi.LifeCycle;
 import ch.qos.logback.core.status.Status;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
-import io.micronaut.aot.core.AOTModule;
 import io.micronaut.aot.core.AOTContext;
+import io.micronaut.aot.core.AOTModule;
 import io.micronaut.aot.core.codegen.AbstractSingleClassFileGenerator;
 import io.micronaut.core.annotation.NonNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.lang.model.element.Modifier;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import static ch.qos.logback.classic.Level.toLevel;
 
 /**
  * A source generator responsible for converting a logback.xml configuration into
@@ -51,12 +71,15 @@ import java.util.Locale;
 public class LogbackConfigurationSourceGenerator extends AbstractSingleClassFileGenerator {
     public static final String ID = "logback.xml.to.java";
     public static final String DESCRIPTION = "Replaces logback.xml with a pure Java configuration (NOT YET IMPLEMENTED!)";
-    private static final Logger LOGGER = LoggerFactory.getLogger(LogbackConfigurationSourceGenerator.class);
 
     @Override
     @NonNull
     protected JavaFile generate() {
-        LOGGER.warn("The logback.xml conversion feature is not implemented yet. Using hardcoded Java configuration.");
+        try {
+            Class.forName("ch.qos.logback.core.model.Model");
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("The logback.xml conversion feature requires logback 1.3 on the AOT optimizer classpath.");
+        }
         TypeSpec typeSpec = TypeSpec.classBuilder("StaticLogbackConfiguration")
                 .addModifiers(Modifier.PUBLIC)
                 .addSuperinterface(Configurator.class)
@@ -75,10 +98,20 @@ public class LogbackConfigurationSourceGenerator extends AbstractSingleClassFile
         return javaFile(typeSpec);
     }
 
+    /**
+     * Returns the name of the logback configuration file.
+     * Can be overridden in tests.
+     *
+     * @return the name of the logback configuration file
+     */
+    protected String getLogbackFileName() {
+        return "logback.xml";
+    }
+
     @Override
     public void generate(@NonNull AOTContext context) {
         super.generate(context);
-        context.registerExcludedResource("logback.xml");
+        context.registerExcludedResource(getLogbackFileName());
         context.registerServiceImplementation(Configurator.class, "StaticLogbackConfiguration");
     }
 
@@ -120,26 +153,217 @@ public class LogbackConfigurationSourceGenerator extends AbstractSingleClassFile
                 .build();
     }
 
-    private static MethodSpec configureMethod() {
+    private MethodSpec configureMethod() {
+        JoranConfigurator joranConfigurator = new JoranConfigurator();
+        LoggerContext context = new LoggerContext();
+        joranConfigurator.setContext(context);
+        try {
+            String fileName = getLogbackFileName();
+            URL logbackFile = getContext().getAnalyzer().getApplicationContext().getClass().getClassLoader().getResource(fileName);
+            if (logbackFile == null) {
+                throw new IllegalStateException("Could not find " + fileName + " file on application classpath");
+            }
+            joranConfigurator.doConfigure(logbackFile);
+        } catch (JoranException e) {
+            throw new RuntimeException(e);
+        }
+        Model model = joranConfigurator.getInterpretationContext().peekModel();
+        CodeBlock.Builder codeBuilder = CodeBlock.builder();
+        BeanDescriptionCache beanDescriptionCache = new BeanDescriptionCache(context);
+        ModelVisitor visitor = new ModelVisitor() {
+            private final Map<String, Set<String>> loggerToAppenders = new HashMap<>();
+            private final Map<String, String> appenderRefToAppenderVarName = new HashMap<>();
+            private final Map<Model, String> modelToVarName = new HashMap<>();
+
+            private String varNameOf(Model model) {
+                return modelToVarName.computeIfAbsent(model, m -> {
+                    String var = toVarName(model);
+                    if (modelToVarName.containsValue(var)) {
+                        var = toVarName(model) + "_" + modelToVarName.size();
+                    }
+                    return var;
+                });
+            }
+
+            private String toVarName(Model model) {
+                String name;
+                if (model instanceof NamedComponentModel) {
+                    name = ((NamedComponentModel) model).getName();
+                } else if (model instanceof LoggerModel) {
+                    name = ((LoggerModel) model).getName();
+                } else {
+                    name = model.getTag();
+                }
+                return name.replaceAll("[^a-zA-Z0-9]", "_").toLowerCase(Locale.US);
+            }
+
+            @Override
+            public void visitRootLogger(RootLoggerModel model, Model parent) {
+                codeBuilder.addStatement("$T _rootLogger = loggerContext.getLogger($T.ROOT_LOGGER_NAME)", ch.qos.logback.classic.Logger.class, ch.qos.logback.classic.Logger.class);
+                String level = model.getLevel();
+                if (level != null) {
+                    codeBuilder.addStatement("_rootLogger.setLevel($T.$L)", ClassName.get(Level.class), toLevel(level));
+                }
+                collectAppenders(model, "_rootLogger");
+            }
+
+            @Override
+            public void visitLogger(LoggerModel model, Model parent) {
+                String loggerVarName = varNameOf(model);
+                codeBuilder.addStatement("$T $L = loggerContext.getLogger($S)", ch.qos.logback.classic.Logger.class, loggerVarName, model.getName());
+                String level = model.getLevel();
+                if (level != null) {
+                    codeBuilder.addStatement("$L.setLevel($T.$L)", loggerVarName, ClassName.get(Level.class), toLevel(level));
+                }
+                String additivity = model.getAdditivity();
+                if (additivity != null) {
+                    codeBuilder.addStatement("$L.setAdditive($L)", loggerVarName, Boolean.valueOf(additivity));
+                }
+                collectAppenders(model, loggerVarName);
+            }
+
+            private void collectAppenders(Model model, String loggerVarName) {
+                Set<String> appenders = model.getSubModels().stream()
+                        .filter(AppenderRefModel.class::isInstance)
+                        .map(AppenderRefModel.class::cast)
+                        .map(AppenderRefModel::getRef)
+                        .collect(Collectors.toSet());
+                loggerToAppenders.put(loggerVarName, appenders);
+            }
+
+            @Override
+            public void visitAppender(AppenderModel model, Model parent) {
+                ClassName appenderName = ClassName.bestGuess(model.getClassName());
+                String varName = varNameOf(model);
+                appenderRefToAppenderVarName.put(model.getName(), varName);
+                codeBuilder.addStatement("$T $L = new $T()", appenderName, varName, appenderName);
+            }
+
+            @Override
+            public void visitImplicit(ImplicitModel model, Model parent) {
+                String className = model.getClassName();
+                if (className == null && parent instanceof ComponentModel) {
+                    generateSetterCode(model, parent);
+                } else if (className != null) {
+                    String varName = varNameOf(model);
+                    ClassName elementType = ClassName.bestGuess(className);
+                    codeBuilder.addStatement("$T $L = new $T()", elementType, varName, elementType);
+                }
+            }
+
+            @Override
+            public void postVisitImplicit(ImplicitModel model, Model parent) {
+                String className = model.getClassName();
+                if (className != null) {
+                    generateSetterCode(model, parent);
+                }
+            }
+
+            @Override
+            public void postVisit(Model model, Model parent) {
+                if (model instanceof ComponentModel) {
+                    String className = ((ComponentModel) model).getClassName();
+                    if (className != null) {
+                        try {
+                            Class<?> clazz = Class.forName(className);
+                            if (ContextAware.class.isAssignableFrom(clazz)) {
+                                codeBuilder.addStatement("$L.setContext(context)", varNameOf(model));
+                            }
+                            if (LifeCycle.class.isAssignableFrom(clazz)) {
+                                codeBuilder.addStatement("$L.start()", varNameOf(model));
+                            }
+                        } catch (ClassNotFoundException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+                ModelVisitor.super.postVisit(model, parent);
+            }
+
+            private void generateSetterCode(ImplicitModel model, Model parent) {
+                if (!maybeGenerateAddOrSet(model, parent, BeanDescription::getSetter)) {
+                    maybeGenerateAddOrSet(model, parent, BeanDescription::getAdder);
+                }
+            }
+
+            private boolean maybeGenerateAddOrSet(ImplicitModel model, Model parent, BiFunction<BeanDescription, String, Method> methodFinder) {
+                try {
+                    String ownerClassName = ((ComponentModel) parent).getClassName();
+                    BeanDescription beanDescription = beanDescriptionCache.getBeanDescription(Class.forName(ownerClassName));
+                    Method method = methodFinder.apply(beanDescription, model.getTag());
+                    if (method != null) {
+                        Class<?> parameterType = method.getParameterTypes()[0];
+                        String parentVarName = varNameOf(parent);
+                        if (model.getBodyText() == null) {
+                            codeBuilder.addStatement("$L.$L($L)", parentVarName, method.getName(), varNameOf(model));
+                            return true;
+                        } else if (parameterType.isPrimitive()) {
+                            Object value = toPrimitiveValue(model, parameterType);
+                            codeBuilder.addStatement("$L.$L($L)", parentVarName, method.getName(), value);
+                            return true;
+                        } else if (String.class.equals(parameterType)) {
+                            codeBuilder.addStatement("$L.$L($S)", parentVarName, method.getName(), model.getBodyText());
+                            return true;
+                        } else {
+                            try {
+                                Method valueOf = parameterType.getDeclaredMethod("valueOf", String.class);
+                                codeBuilder.addStatement("$L.$L($T.valueOf($S))", parentVarName, method.getName(), ClassName.get(parameterType), model.getBodyText());
+                                return true;
+                            } catch (NoSuchMethodException e) {
+                                throw new RuntimeException("Unable to convert type" + parameterType);
+                            }
+                        }
+                    }
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+                return false;
+            }
+
+            private Object toPrimitiveValue(ImplicitModel model, Class<?> parameterType) {
+                Object value;
+                String bodyText = model.getBodyText();
+                if (parameterType.equals(boolean.class)) {
+                    value = Boolean.valueOf(bodyText);
+                } else if (parameterType.equals(byte.class)) {
+                    value = Byte.valueOf(bodyText);
+                } else if (parameterType.equals(char.class)) {
+                    value = bodyText.charAt(0);
+                } else if (parameterType.equals(double.class)) {
+                    value = Double.valueOf(bodyText);
+                } else if (parameterType.equals(float.class)) {
+                    value = Float.valueOf(bodyText);
+                } else if (parameterType.equals(int.class)) {
+                    value = Integer.valueOf(bodyText);
+                } else if (parameterType.equals(long.class)) {
+                    value = Long.valueOf(bodyText);
+                } else if (parameterType.equals(short.class)) {
+                    value = Short.valueOf(bodyText);
+                } else {
+                    value = bodyText;
+                }
+                return value;
+            }
+
+            @Override
+            public void postVisitConfiguration(ConfigurationModel model, Model parent) {
+                for (Map.Entry<String, Set<String>> entry : loggerToAppenders.entrySet()) {
+                    String loggerName = entry.getKey();
+                    for (String appenderRef : entry.getValue()) {
+                        String varName = appenderRefToAppenderVarName.get(appenderRef);
+                        if (varName != null) {
+                            codeBuilder.addStatement("$L.addAppender($L)", loggerName, varName);
+                        }
+                    }
+                }
+            }
+        };
+        visitor.visit(model);
+
         return MethodSpec.methodBuilder("configure")
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(LoggerContext.class, "loggerContext")
-                .addStatement("$T console = new $T<>()", ParameterizedTypeName.get(ConsoleAppender.class, ILoggingEvent.class), ConsoleAppender.class)
-                .addStatement("console.setWithJansi(true)")
-                .addStatement("console.setContext(context)")
-                .addStatement("$T encoder = new $T();", PatternLayoutEncoder.class, PatternLayoutEncoder.class)
-                .addStatement("encoder.setPattern(\"%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n\")")
-                .addStatement("encoder.setContext(context)")
-                .addStatement("console.setEncoder(encoder)")
-                .addStatement("$T logger = loggerContext.getLogger($T.ROOT_LOGGER_NAME)", ch.qos.logback.classic.Logger.class, ch.qos.logback.classic.Logger.class)
-                .addStatement("logger.addAppender(console)")
-                .addStatement("logger.setLevel($T.INFO)", Level.class)
-                .addStatement("logger = loggerContext.getLogger(\"io.micronaut.core.io.service.SoftServiceLoader\")")
-                .addStatement("logger.setLevel($T.DEBUG)", Level.class)
-                .addStatement("logger.setAdditive(false)")
-                .addStatement("logger.addAppender(console)")
-                .addStatement("encoder.start()")
-                .addStatement("console.start()")
+                .addCode(codeBuilder.build())
                 .build();
     }
 
@@ -147,5 +371,90 @@ public class LogbackConfigurationSourceGenerator extends AbstractSingleClassFile
         return FieldSpec.builder(Context.class, "context")
                 .addModifiers(Modifier.PRIVATE)
                 .build();
+    }
+
+    interface ModelVisitor {
+
+        default void visit(Model model) {
+            visit(model, null);
+        }
+
+        default void visit(Model model, Model parent) {
+            previsit(model, parent);
+            model.getSubModels().forEach(m -> visit(m, model));
+            postVisit(model, parent);
+        }
+
+        default void previsit(Model model, Model parent) {
+            if (model instanceof RootLoggerModel) {
+                visitRootLogger((RootLoggerModel) model, parent);
+            }
+            if (model instanceof AppenderModel) {
+                visitAppender((AppenderModel) model, parent);
+            }
+            if (model instanceof ImplicitModel) {
+                visitImplicit((ImplicitModel) model, parent);
+            }
+            if (model instanceof LoggerModel) {
+                visitLogger((LoggerModel) model, parent);
+            }
+            if (model instanceof ConfigurationModel) {
+                visitConfiguration((ConfigurationModel) model, parent);
+            }
+        }
+
+        default void visitConfiguration(ConfigurationModel model, Model parent) {
+
+        }
+
+        default void postVisitConfiguration(ConfigurationModel model, Model parent) {
+
+        }
+
+        default void postVisit(Model model, Model parent) {
+            if (model instanceof RootLoggerModel) {
+                postVisitRootLogger((RootLoggerModel) model, parent);
+            }
+            if (model instanceof AppenderModel) {
+                postVisitAppender((AppenderModel) model, parent);
+            }
+            if (model instanceof ImplicitModel) {
+                postVisitImplicit((ImplicitModel) model, parent);
+            }
+            if (model instanceof LoggerModel) {
+                postVisitLogger((LoggerModel) model, parent);
+            }
+            if (model instanceof ConfigurationModel) {
+                postVisitConfiguration((ConfigurationModel) model, parent);
+            }
+        }
+
+        default void visitRootLogger(RootLoggerModel model, Model parent) {
+        }
+
+        default void postVisitRootLogger(RootLoggerModel model, Model parent) {
+        }
+
+        default void visitLogger(LoggerModel model, Model parent) {
+        }
+
+        default void postVisitLogger(LoggerModel model, Model parent) {
+        }
+
+        default void visitAppender(AppenderModel model, Model parent) {
+
+        }
+
+        default void postVisitAppender(AppenderModel model, Model parent) {
+
+        }
+
+        default void visitImplicit(ImplicitModel model, Model parent) {
+
+        }
+
+        default void postVisitImplicit(ImplicitModel model, Model parent) {
+
+        }
     }
 }

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGeneratorTest.groovy
@@ -19,16 +19,373 @@ import io.micronaut.aot.core.AOTCodeGenerator
 import io.micronaut.aot.core.codegen.AbstractSourceGeneratorSpec
 
 class LogbackConfigurationSourceGeneratorTest extends AbstractSourceGeneratorSpec {
+    String configFileName = "logback.xml"
+
     @Override
     AOTCodeGenerator newGenerator() {
-        new LogbackConfigurationSourceGenerator()
+        new TestLogbackConfigurationSourceGenerator()
     }
 
     def "adds logback.xml to the excluded resources"() {
+        configFileName = "logback-test1.xml"
+
         when:
         generate()
 
         then:
-        excludesResources("logback.xml")
+        excludesResources("logback-test1.xml")
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            hasClass("StaticLogbackConfiguration") {
+                withSources """package io.micronaut.test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.Configurator;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.status.Status;
+import java.lang.String;
+import java.lang.Throwable;
+
+public class StaticLogbackConfiguration implements Configurator {
+  private Context context;
+
+  public void configure(LoggerContext loggerContext) {
+    ConsoleAppender stdout = new ConsoleAppender();
+    stdout.setWithJansi(true);
+    PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+    encoder.setPattern("%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n");
+    encoder.setContext(context);
+    encoder.start();
+    stdout.setEncoder(encoder);
+    stdout.setContext(context);
+    stdout.start();
+    Logger _rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
+    _rootLogger.setLevel(Level.INFO);
+    Logger io_micronaut_core_optim_staticoptimizations = loggerContext.getLogger("io.micronaut.core.optim.StaticOptimizations");
+    io_micronaut_core_optim_staticoptimizations.setLevel(Level.DEBUG);
+    io_micronaut_core_optim_staticoptimizations.setAdditive(false);
+    Logger io_micronaut_aot = loggerContext.getLogger("io.micronaut.aot");
+    io_micronaut_aot.setLevel(Level.DEBUG);
+    io_micronaut_aot.setAdditive(false);
+    Logger io_micronaut_core_io_service_softserviceloader = loggerContext.getLogger("io.micronaut.core.io.service.SoftServiceLoader");
+    io_micronaut_core_io_service_softserviceloader.setLevel(Level.DEBUG);
+    io_micronaut_core_io_service_softserviceloader.setAdditive(false);
+    _rootLogger.addAppender(stdout);
+    io_micronaut_core_optim_staticoptimizations.addAppender(stdout);
+    io_micronaut_core_io_service_softserviceloader.addAppender(stdout);
+    io_micronaut_aot.addAppender(stdout);
+  }
+
+  public void setContext(Context context) {
+    this.context = context;
+  }
+
+  public Context getContext() {
+    return context;
+  }
+
+  public void addStatus(Status status) {
+  }
+
+  public void addInfo(String info) {
+  }
+
+  public void addInfo(String info, Throwable ex) {
+  }
+
+  public void addWarn(String warn) {
+  }
+
+  public void addWarn(String warn, Throwable ex) {
+  }
+
+  public void addError(String error) {
+  }
+
+  public void addError(String error, Throwable ex) {
+  }
+}
+"""
+            }
+            compiles()
+        }
+    }
+
+    def "converts configuration using file logger"() {
+        configFileName = "logback-test2.xml"
+
+        when:
+        generate()
+
+        then:
+        excludesResources("logback-test2.xml")
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            hasClass("StaticLogbackConfiguration") {
+                withSources """package io.micronaut.test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.Configurator;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.FileAppender;
+import ch.qos.logback.core.status.Status;
+import java.lang.String;
+import java.lang.Throwable;
+
+public class StaticLogbackConfiguration implements Configurator {
+  private Context context;
+
+  public void configure(LoggerContext loggerContext) {
+    ConsoleAppender console = new ConsoleAppender();
+    PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+    encoder.setPattern("%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n");
+    encoder.setContext(context);
+    encoder.start();
+    console.setEncoder(encoder);
+    console.setContext(context);
+    console.start();
+    FileAppender file = new FileAppender();
+    file.setFile("/tmp/logback.log");
+    file.setAppend(true);
+    file.setImmediateFlush(true);
+    PatternLayoutEncoder encoder_3 = new PatternLayoutEncoder();
+    encoder_3.setPattern("%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n");
+    encoder_3.setContext(context);
+    encoder_3.start();
+    file.setEncoder(encoder_3);
+    file.setContext(context);
+    file.start();
+    Logger org_acme = loggerContext.getLogger("org.acme");
+    Logger _rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
+    _rootLogger.setLevel(Level.INFO);
+    _rootLogger.addAppender(file);
+    org_acme.addAppender(console);
+  }
+
+  public void setContext(Context context) {
+    this.context = context;
+  }
+
+  public Context getContext() {
+    return context;
+  }
+
+  public void addStatus(Status status) {
+  }
+
+  public void addInfo(String info) {
+  }
+
+  public void addInfo(String info, Throwable ex) {
+  }
+
+  public void addWarn(String warn) {
+  }
+
+  public void addWarn(String warn, Throwable ex) {
+  }
+
+  public void addError(String error) {
+  }
+
+  public void addError(String error, Throwable ex) {
+  }
+}
+"""
+            }
+            compiles()
+        }
+    }
+
+    def "converts configuration using nested components"() {
+        configFileName = "logback-test3.xml"
+
+        when:
+        generate()
+
+        then:
+        excludesResources("logback-test3.xml")
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            hasClass("StaticLogbackConfiguration") {
+                withSources """package io.micronaut.test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.Configurator;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
+import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
+import ch.qos.logback.core.status.Status;
+import ch.qos.logback.core.util.FileSize;
+import java.lang.String;
+import java.lang.Throwable;
+
+public class StaticLogbackConfiguration implements Configurator {
+  private Context context;
+
+  public void configure(LoggerContext loggerContext) {
+    RollingFileAppender file = new RollingFileAppender();
+    file.setFile("/tmp/logback.log");
+    TimeBasedRollingPolicy rollingpolicy = new TimeBasedRollingPolicy();
+    rollingpolicy.setFileNamePattern("/tmp/logback.%d{yyyy-MM-dd}.%i.log");
+    SizeAndTimeBasedFNATP timebasedfilenamingandtriggeringpolicy = new SizeAndTimeBasedFNATP();
+    timebasedfilenamingandtriggeringpolicy.setMaxFileSize(FileSize.valueOf("10MB"));
+    timebasedfilenamingandtriggeringpolicy.setContext(context);
+    timebasedfilenamingandtriggeringpolicy.start();
+    rollingpolicy.setTimeBasedFileNamingAndTriggeringPolicy(timebasedfilenamingandtriggeringpolicy);
+    rollingpolicy.setMaxHistory(7);
+    rollingpolicy.setContext(context);
+    rollingpolicy.start();
+    file.setRollingPolicy(rollingpolicy);
+    PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+    encoder.setPattern("%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n");
+    encoder.setOutputPatternAsHeader(true);
+    encoder.setContext(context);
+    encoder.start();
+    file.setEncoder(encoder);
+    file.setContext(context);
+    file.start();
+    Logger _rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
+    _rootLogger.setLevel(Level.INFO);
+    _rootLogger.addAppender(file);
+  }
+
+  public void setContext(Context context) {
+    this.context = context;
+  }
+
+  public Context getContext() {
+    return context;
+  }
+
+  public void addStatus(Status status) {
+  }
+
+  public void addInfo(String info) {
+  }
+
+  public void addInfo(String info, Throwable ex) {
+  }
+
+  public void addWarn(String warn) {
+  }
+
+  public void addWarn(String warn, Throwable ex) {
+  }
+
+  public void addError(String error) {
+  }
+
+  public void addError(String error, Throwable ex) {
+  }
+}
+"""
+            }
+            compiles()
+        }
+    }
+
+    def "converts configuration using filters"() {
+        configFileName = "logback-test4.xml"
+
+        when:
+        generate()
+
+        then:
+        excludesResources("logback-test4.xml")
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            hasClass("StaticLogbackConfiguration") {
+                withSources """package io.micronaut.test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.filter.LevelFilter;
+import ch.qos.logback.classic.spi.Configurator;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.spi.FilterReply;
+import ch.qos.logback.core.status.Status;
+import java.lang.String;
+import java.lang.Throwable;
+
+public class StaticLogbackConfiguration implements Configurator {
+  private Context context;
+
+  public void configure(LoggerContext loggerContext) {
+    ConsoleAppender console = new ConsoleAppender();
+    PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+    encoder.setPattern("%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n");
+    encoder.setContext(context);
+    encoder.start();
+    console.setEncoder(encoder);
+    LevelFilter filter = new LevelFilter();
+    filter.setLevel(Level.valueOf("INFO"));
+    filter.setOnMatch(FilterReply.valueOf("DENY"));
+    filter.setOnMismatch(FilterReply.valueOf("ACCEPT"));
+    filter.setContext(context);
+    filter.start();
+    console.addFilter(filter);
+    console.setContext(context);
+    console.start();
+    Logger _rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
+    _rootLogger.setLevel(Level.INFO);
+    _rootLogger.addAppender(console);
+  }
+
+  public void setContext(Context context) {
+    this.context = context;
+  }
+
+  public Context getContext() {
+    return context;
+  }
+
+  public void addStatus(Status status) {
+  }
+
+  public void addInfo(String info) {
+  }
+
+  public void addInfo(String info, Throwable ex) {
+  }
+
+  public void addWarn(String warn) {
+  }
+
+  public void addWarn(String warn, Throwable ex) {
+  }
+
+  public void addError(String error) {
+  }
+
+  public void addError(String error, Throwable ex) {
+  }
+}
+"""
+            }
+            compiles()
+        }
+    }
+
+    class TestLogbackConfigurationSourceGenerator extends LogbackConfigurationSourceGenerator {
+        @Override
+        protected String getLogbackFileName() {
+            configFileName
+        }
     }
 }

--- a/aot-std-optimizers/src/test/resources/logback-test1.xml
+++ b/aot-std-optimizers/src/test/resources/logback-test1.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="io.micronaut.core.optim.StaticOptimizations" level="debug" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+    <logger name="io.micronaut.aot" level="debug" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+    <logger name="io.micronaut.core.io.service.SoftServiceLoader" level="debug" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+</configuration>

--- a/aot-std-optimizers/src/test/resources/logback-test2.xml
+++ b/aot-std-optimizers/src/test/resources/logback-test2.xml
@@ -1,0 +1,24 @@
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="ch.qos.logback.core.FileAppender">
+        <file>/tmp/logback.log</file>
+        <append>true</append>
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.acme">
+        <appender-ref ref="console"/>
+    </logger>
+
+    <root level="info">
+        <appender-ref ref="file" />
+    </root>
+</configuration>

--- a/aot-std-optimizers/src/test/resources/logback-test3.xml
+++ b/aot-std-optimizers/src/test/resources/logback-test3.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/tmp/logback.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/tmp/logback.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy
+                    class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+            <outputPatternAsHeader>true</outputPatternAsHeader>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="file" />
+    </root>
+</configuration>

--- a/aot-std-optimizers/src/test/resources/logback-test4.xml
+++ b/aot-std-optimizers/src/test/resources/logback-test4.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>DENY</onMatch>
+            <onMismatch>ACCEPT</onMismatch>
+        </filter>
+    </appender>
+    <root level="info">
+        <appender-ref ref="console" />
+    </root>
+</configuration>


### PR DESCRIPTION
This commit introduces proper conversion of logback.xml files to Java. For this purpose, it uses logback 1.3. Because it's still in alpha, this isn't ideal. However, the converter can use logback 1.3, while the actual application can use 1.2.x. This requires,
on the Gradle plugin side, to use:

```gradle
dependencies {
    aotPlugins("ch.qos.logback:logback-classic:1.3.0-alpha12")
    aotPlugins("org.fusesource.jansi:jansi:1.18")
}
```

The code has a sanity check to make sure that this is the case. It's also worth noting that the conversion implies the use of logback classic.