### PR TITLE
Cleanup generated POM files

### DIFF
--- a/build-logic/src/main/groovy/io.micronaut.build.internal.aot-project.gradle
+++ b/build-logic/src/main/groovy/io.micronaut.build.internal.aot-project.gradle
@@ -37,3 +37,39 @@ pluginManager.withPlugin("java-test-fixtures") {
         outgoing.capability("$group:micronaut-${project.name}-test-fixtures:$projectVersion")
     }
 }
+
+// compileOnlyApi dependencies end up as `<scope>compile</scope>` in Maven
+// which isn't correct so we need to fix them and mark them as provided
+publishing {
+    publications.withType(MavenPublication) {
+        pom.withXml {
+            configurations.all {
+                if (it.name == 'compileOnlyApi') {
+                    def compileOnlyApi = it
+                    def deps = compileOnlyApi.dependencies.findAll {
+                        it instanceof ExternalModuleDependency
+                    }.collect {
+                        it.name
+                    } as Set<String>
+                    asNode().dependencies.dependency.findAll { xmlDep ->
+                        if (xmlDep.artifactId.text() in deps) {
+                            def scope = xmlDep.scope[0]
+                            if (!scope) {
+                                scope = xmlDep.appendNode('scope')
+                            }
+                            scope.value = 'provided'
+                        }
+                    }
+                }
+            }
+            // We don't need any optional dependency in the POM, especially
+            // because those come from test fixtures
+            asNode().dependencies.each { dependencies ->
+                dependencies.children().removeAll(dependencies.dependency.findAll {
+                    def opt = it.optional[0]
+                    opt && opt.text() == 'true'
+                })
+            }
+        }
+    }
+}


### PR DESCRIPTION
The POM files generated by Micronaut AOT have 2 different issues:

- `compileOnlyApi` dependencies are exposed as scope compile instead of provided
- test fixture dependencies end up as optional dependencies

In practice, test fixtures are not intended to be consumed from Maven,
so there's no point in "documenting" them as optional. Similarly, the
compile only dependencies should only be used by AOT plugins, which is
only provided by Gradle.

Fixes #74