### PR TITLE
Fix deduceEnvironment optimization

### DIFF
--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/DeduceEnvironmentSourceGenerator.java
@@ -55,15 +55,15 @@ public class DeduceEnvironmentSourceGenerator extends AbstractCodeGenerator {
         Set<String> environmentNames = analyzer.getEnvironmentNames();
         BeanContextConfiguration contextConfiguration = analyzer.getApplicationContext().getContextConfiguration();
         if (contextConfiguration instanceof ApplicationContextConfiguration) {
-            ((ApplicationContextConfiguration) contextConfiguration).getDeduceEnvironments().ifPresent(deduceEnvironments -> {
-                if (deduceEnvironments) {
-                    Collection<String> packages = analyzer.getApplicationContext().getEnvironment().getPackages();
-                    context.registerGeneratedSourceFile(
-                            context.javaFile(buildApplicationContextConfigurer(environmentNames, packages))
-                    );
-                    context.registerServiceImplementation(ApplicationContextConfigurer.class, DEDUCED_ENVIRONMENT_CONFIGURER);
-                }
-            });
+            ApplicationContextConfiguration applicationContextConfiguration = (ApplicationContextConfiguration) contextConfiguration;
+            boolean deduceEnvironments = applicationContextConfiguration.getDeduceEnvironments().orElse(true);
+            if (deduceEnvironments) {
+                Collection<String> packages = analyzer.getApplicationContext().getEnvironment().getPackages();
+                context.registerGeneratedSourceFile(
+                        context.javaFile(buildApplicationContextConfigurer(environmentNames, packages))
+                );
+                context.registerServiceImplementation(ApplicationContextConfigurer.class, DEDUCED_ENVIRONMENT_CONFIGURER);
+            }
         }
     }
 


### PR DESCRIPTION
This commit fixed the way the deduce environment optimization detects
if it should run or not. Previously it would only run if `deduceEnvironment`
was explicitly set to `true`, not if it was using the default.
With this change, if the user didn't say anything or if it's set to true,
then the optimization will run. Otherwise, we do nothing as it will
already be configured to `false`.