### PR TITLE
Expose properties so that an app can determine if AOT is active

### DIFF
--- a/aot-core/src/main/java/io/micronaut/aot/core/codegen/MapGenerator.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/codegen/MapGenerator.java
@@ -56,21 +56,7 @@ public class MapGenerator {
             if (CharSequence.class.isAssignableFrom(valueClass)) {
                 return "\"" + value + "\"";
             } else if (Number.class.isAssignableFrom(valueClass) || Boolean.class.isAssignableFrom(valueClass)) {
-                String format = String.valueOf(value);
-                String prefix = "";
-                String appendix = "";
-                if (Long.class.equals(valueClass)) {
-                    appendix = "L";
-                } else if (Double.class.equals(valueClass)) {
-                    appendix = "D";
-                } else if (Float.class.equals(valueClass)) {
-                    appendix = "F";
-                } else if (Byte.class.equals(valueClass)) {
-                    prefix = "(byte) ";
-                } else if (Short.class.equals(valueClass)) {
-                    prefix = "(short) ";
-                }
-                return prefix + format + appendix;
+                return convertNumberOrBoolean(valueClass, value);
             } else if (List.class.isAssignableFrom(valueClass)) {
                 return generateListMethod((List<?>) value, builder);
             } else if (Map.class.isAssignableFrom(valueClass)) {
@@ -79,6 +65,24 @@ public class MapGenerator {
                 throw new UnsupportedOperationException("Configuration map contains an entry of type " + valueClass + " which is not supported yet. Please file a bug report.");
             }
         }
+    }
+
+    private String convertNumberOrBoolean(Class<?> valueClass, Object value) {
+        String format = String.valueOf(value);
+        String prefix = "";
+        String appendix = "";
+        if (Long.class.equals(valueClass)) {
+            appendix = "L";
+        } else if (Double.class.equals(valueClass)) {
+            appendix = "D";
+        } else if (Float.class.equals(valueClass)) {
+            appendix = "F";
+        } else if (Byte.class.equals(valueClass)) {
+            prefix = "(byte) ";
+        } else if (Short.class.equals(valueClass)) {
+            prefix = "(short) ";
+        }
+        return prefix + format + appendix;
     }
 
     private String generateListMethod(List<?> value, TypeSpec.Builder builder) {

--- a/aot-core/src/main/java/io/micronaut/aot/core/codegen/MapGenerator.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/codegen/MapGenerator.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aot.core.codegen;
+
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.STATIC;
+
+/**
+ * A helper class to generate maps.
+ */
+public class MapGenerator {
+    private int methodCount = 0;
+
+    public final CodeBlock generateMap(TypeSpec.Builder builder, Map<String, Object> values) {
+        CodeBlock.Builder mapBuilder = CodeBlock.builder();
+        mapBuilder.add("new $T() {{\n", HashMap.class);
+        for (Map.Entry<String, Object> entry : values.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            mapBuilder.add("$L", "put(\"" + key + "\", " + convertValueToSource(value, builder));
+            mapBuilder.add(");\n");
+        }
+        mapBuilder.add("}}");
+        return mapBuilder.build();
+    }
+
+    private String convertValueToSource(Object value, TypeSpec.Builder builder) {
+        if (value == null) {
+            return "null";
+        } else {
+            Class<?> valueClass = value.getClass();
+            if (CharSequence.class.isAssignableFrom(valueClass)) {
+                return "\"" + value + "\"";
+            } else if (Number.class.isAssignableFrom(valueClass) || Boolean.class.isAssignableFrom(valueClass)) {
+                String format = String.valueOf(value);
+                String prefix = "";
+                String appendix = "";
+                if (Long.class.equals(valueClass)) {
+                    appendix = "L";
+                } else if (Double.class.equals(valueClass)) {
+                    appendix = "D";
+                } else if (Float.class.equals(valueClass)) {
+                    appendix = "F";
+                } else if (Byte.class.equals(valueClass)) {
+                    prefix = "(byte) ";
+                } else if (Short.class.equals(valueClass)) {
+                    prefix = "(short) ";
+                }
+                return prefix + format + appendix;
+            } else if (List.class.isAssignableFrom(valueClass)) {
+                return generateListMethod((List<?>) value, builder);
+            } else if (Map.class.isAssignableFrom(valueClass)) {
+                return generateMapMethod((Map<?, ?>) value, builder);
+            } else {
+                throw new UnsupportedOperationException("Configuration map contains an entry of type " + valueClass + " which is not supported yet. Please file a bug report.");
+            }
+        }
+    }
+
+    private String generateListMethod(List<?> value, TypeSpec.Builder builder) {
+        String methodName = "list" + methodCount++;
+        MethodSpec.Builder listMethod = MethodSpec.methodBuilder(methodName)
+                .addModifiers(PRIVATE, STATIC)
+                .returns(List.class);
+        if (value.isEmpty()) {
+            listMethod.addStatement("return $T.emptyList()", Collections.class);
+        } else if (value.size() == 1) {
+            listMethod.addStatement("return $T.singletonList($L)", Collections.class, convertValueToSource(value.get(0), builder));
+        } else {
+            listMethod.addStatement("$T result = new $T<>($L)", List.class, ArrayList.class, value.size());
+            for (Object o : value) {
+                listMethod.addStatement("result.add(" + convertValueToSource(o, builder) + ")");
+            }
+            listMethod.addStatement("return result");
+        }
+        builder.addMethod(listMethod.build());
+        return methodName + "()";
+    }
+
+    private String generateMapMethod(Map<?, ?> value, TypeSpec.Builder builder) {
+        String methodName = "map" + methodCount++;
+        MethodSpec.Builder mapMethod = MethodSpec.methodBuilder(methodName)
+                .addModifiers(PRIVATE, STATIC)
+                .returns(Map.class);
+        if (value.isEmpty()) {
+            mapMethod.addStatement("return $.emptyMap()", Collections.class);
+        } else if (value.size() == 1) {
+            Map.Entry<?, ?> entry = value.entrySet().iterator().next();
+            mapMethod.addStatement("return $T.singletonMap($L, $L)", Collections.class, convertValueToSource(entry.getKey(), builder), convertValueToSource(entry.getValue(), builder));
+        } else {
+            mapMethod.addStatement("$T result = new $T<>($L)", Map.class, LinkedHashMap.class, value.size());
+            for (Map.Entry<?, ?> entry : value.entrySet()) {
+                mapMethod.addStatement("result.put(" + convertValueToSource(entry.getKey(), builder) + ", " + convertValueToSource(entry.getValue(), builder) + ")");
+            }
+            mapMethod.addStatement("return result");
+        }
+        builder.addMethod(mapMethod.build());
+        return methodName + "()";
+    }
+
+}

--- a/aot-core/src/test/groovy/io/micronaut/aot/core/codegen/ApplicationContextConfigurerGeneratorTest.groovy
+++ b/aot-core/src/test/groovy/io/micronaut/aot/core/codegen/ApplicationContextConfigurerGeneratorTest.groovy
@@ -41,10 +41,28 @@ class ApplicationContextConfigurerGeneratorTest extends AbstractSourceGeneratorS
             hasClass('AOTApplicationContextConfigurer') {
                 withSources '''package io.micronaut.test;
 
+import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.ApplicationContextConfigurer;
+import java.lang.Override;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 
 public class AOTApplicationContextConfigurer implements ApplicationContextConfigurer {
   static {
+  }
+
+  private static List list0() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void configure(ApplicationContextBuilder builder) {
+    builder.properties(new HashMap() {{
+        put("micronaut.aot.enabled", true);
+        put("micronaut.aot.runtime", "JIT");
+        put("micronaut.aot.optimizations", list0());
+        }});
   }
 }'''
             }
@@ -65,7 +83,12 @@ public class AOTApplicationContextConfigurer implements ApplicationContextConfig
             hasClass('AOTApplicationContextConfigurer') {
                 withSources '''package io.micronaut.test;
 
+import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.ApplicationContextConfigurer;
+import java.lang.Override;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 public class AOTApplicationContextConfigurer implements ApplicationContextConfigurer {
   static {
@@ -77,6 +100,22 @@ public class AOTApplicationContextConfigurer implements ApplicationContextConfig
   }
 
   private static void initializer2() {
+  }
+
+  private static List list0() {
+    List result = new ArrayList<>(2);
+    result.add("static-init");
+    result.add("static-init");
+    return result;
+  }
+
+  @Override
+  public void configure(ApplicationContextBuilder builder) {
+    builder.properties(new HashMap() {{
+        put("micronaut.aot.enabled", true);
+        put("micronaut.aot.runtime", "JIT");
+        put("micronaut.aot.optimizations", list0());
+        }});
   }
 }
 '''

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/MapPropertySourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/MapPropertySourceGenerator.java
@@ -15,30 +15,23 @@
  */
 package io.micronaut.aot.std.sourcegen;
 
-import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
 import io.micronaut.aot.core.AOTModule;
 import io.micronaut.aot.core.Option;
 import io.micronaut.aot.core.codegen.AbstractSingleClassFileGenerator;
+import io.micronaut.aot.core.codegen.MapGenerator;
 import io.micronaut.context.env.MapPropertySource;
 import io.micronaut.core.annotation.Generated;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import static io.micronaut.aot.std.sourcegen.MapPropertySourceGenerator.BASE_ORDER_OPTION;
-import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PUBLIC;
-import static javax.lang.model.element.Modifier.STATIC;
 
 /**
  * A source generator which generates a map property source with a fixed
@@ -60,100 +53,12 @@ public class MapPropertySourceGenerator extends AbstractSingleClassFileGenerator
 
     private final String resourceName;
     private final Map<String, Object> values;
-    private int methodCount = 0;
 
     public MapPropertySourceGenerator(
             String resourceName,
             Map<String, Object> values) {
         this.resourceName = resourceName;
         this.values = values;
-    }
-
-    private CodeBlock generateMap(TypeSpec.Builder builder) {
-        CodeBlock.Builder mapBuilder = CodeBlock.builder();
-        mapBuilder.add("new $T() {{\n", HashMap.class);
-        for (Map.Entry<String, Object> entry : values.entrySet()) {
-            String key = entry.getKey();
-            Object value = entry.getValue();
-            mapBuilder.add("$L", "put(\"" + key + "\", " + convertValueToSource(value, builder));
-            mapBuilder.add(");\n");
-        }
-        mapBuilder.add("}}");
-        return mapBuilder.build();
-    }
-
-    private String convertValueToSource(Object value, TypeSpec.Builder builder) {
-        if (value == null) {
-             return "null";
-        } else {
-            Class<?> valueClass = value.getClass();
-            if (CharSequence.class.isAssignableFrom(valueClass)) {
-                return "\"" + value + "\"";
-            } else if (Number.class.isAssignableFrom(valueClass) || Boolean.class.isAssignableFrom(valueClass)) {
-                String format = String.valueOf(value);
-                String prefix = "";
-                String appendix = "";
-                if (Long.class.equals(valueClass)) {
-                    appendix = "L";
-                } else if (Double.class.equals(valueClass)) {
-                    appendix = "D";
-                } else if (Float.class.equals(valueClass)) {
-                    appendix = "F";
-                } else if (Byte.class.equals(valueClass)) {
-                    prefix = "(byte) ";
-                } else if (Short.class.equals(valueClass)) {
-                    prefix = "(short) ";
-                }
-                return prefix + format + appendix;
-            } else if (List.class.isAssignableFrom(valueClass)) {
-                return generateListMethod((List<?>) value, builder);
-            } else if (Map.class.isAssignableFrom(valueClass)) {
-                return generateMapMethod((Map<?, ?>) value, builder);
-            } else {
-                throw new UnsupportedOperationException("Configuration map contains an entry of type " + valueClass + " which is not supported yet. Please file a bug report.");
-            }
-        }
-    }
-
-    private String generateListMethod(List<?> value, TypeSpec.Builder builder) {
-        String methodName = "list" + methodCount++;
-        MethodSpec.Builder listMethod = MethodSpec.methodBuilder(methodName)
-                .addModifiers(PRIVATE, STATIC)
-                .returns(List.class);
-        if (value.isEmpty()) {
-            listMethod.addStatement("return $.emptyList()", Collections.class);
-        } else if (value.size() == 1) {
-            listMethod.addStatement("return $T.singletonList($L)", Collections.class, convertValueToSource(value.get(0), builder));
-        } else {
-            listMethod.addStatement("$T result = new $T<>($L)", List.class, ArrayList.class, value.size());
-            for (Object o : value) {
-                listMethod.addStatement("result.add(" + convertValueToSource(o, builder) + ")");
-            }
-            listMethod.addStatement("return result");
-        }
-        builder.addMethod(listMethod.build());
-        return methodName + "()";
-    }
-
-    private String generateMapMethod(Map<?, ?> value, TypeSpec.Builder builder) {
-        String methodName = "map" + methodCount++;
-        MethodSpec.Builder mapMethod = MethodSpec.methodBuilder(methodName)
-                .addModifiers(PRIVATE, STATIC)
-                .returns(Map.class);
-        if (value.isEmpty()) {
-            mapMethod.addStatement("return $.emptyMap()", Collections.class);
-        } else if (value.size() == 1) {
-            Map.Entry<?, ?> entry = value.entrySet().iterator().next();
-            mapMethod.addStatement("return $T.singletonMap($L, $L)", Collections.class, convertValueToSource(entry.getKey(), builder), convertValueToSource(entry.getValue(), builder));
-        } else {
-            mapMethod.addStatement("$T result = new $T<>($L)", Map.class, LinkedHashMap.class, value.size());
-            for (Map.Entry<?, ?> entry : value.entrySet()) {
-                mapMethod.addStatement("result.put(" + convertValueToSource(entry.getKey(), builder) + ", " + convertValueToSource(entry.getValue(), builder) + ")");
-            }
-            mapMethod.addStatement("return result");
-        }
-        builder.addMethod(mapMethod.build());
-        return methodName + "()";
     }
 
     @Override
@@ -167,8 +72,9 @@ public class MapPropertySourceGenerator extends AbstractSingleClassFileGenerator
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(typeName)
                 .addModifiers(PUBLIC)
                 .superclass(MapPropertySource.class);
+        MapGenerator generator = new MapGenerator();
         typeBuilder.addMethod(MethodSpec.constructorBuilder()
-                        .addStatement("super($S, $L)", resourceName, generateMap(typeBuilder))
+                        .addStatement("super($S, $L)", resourceName, generator.generateMap(typeBuilder, values))
                         .build())
                 .addMethod(MethodSpec.methodBuilder("getOrder")
                         .addModifiers(PUBLIC)


### PR DESCRIPTION
This commit introduces an internal optimization which exposes new
properties to the application runtime, so that it can determine if
AOT is enabled. An easy way is for an application to define a bean
annotated with `@ConfigurationProperties`:

```java
@ConfigurationProperties("micronaut.aot")
public class AotConfiguration {
    private boolean enabled;
    private String runtime;
    private List<String> optimizations;
    ...
}
```

The diagnostics that we expose are intentionally limited.
For example, we don't want to expose the whole configuration,
as it would contain entries which are sensitive to the build
environment (absolute paths for example) which would defeat
caching.