### PR TITLE
Provide meaningful samples

### DIFF
--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/AbstractStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/AbstractStaticServiceLoaderSourceGenerator.java
@@ -65,6 +65,8 @@ public abstract class AbstractStaticServiceLoaderSourceGenerator extends Abstrac
     public static final String REJECTED_CLASSES = "serviceloading.rejected.impls";
     public static final String FORCE_INCLUDE = "serviceloading.force.include.impls";
 
+    protected static final String DEFAULT_SERVICE_TYPES = "io.micronaut.context.env.PropertySourceLoader,io.micronaut.inject.BeanConfiguration,io.micronaut.inject.BeanDefinitionReference,io.micronaut.http.HttpRequestFactory,io.micronaut.http.HttpResponseFactory,io.micronaut.core.beans.BeanIntrospectionReference";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractStaticServiceLoaderSourceGenerator.class);
 
     protected AOTContext context;

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/JitStaticServiceLoaderSourceGenerator.java
@@ -51,7 +51,7 @@ import static javax.lang.model.element.Modifier.STATIC;
                 @Option(
                         key = "service.types",
                         description = "The list of service types to be scanned (comma separated)",
-                        sampleValue = "io.micronaut.Service1,io.micronaut.Service2"
+                        sampleValue = AbstractStaticServiceLoaderSourceGenerator.DEFAULT_SERVICE_TYPES
                 ),
                 @Option(
                         key = "serviceloading.rejected.impls",

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/KnownMissingTypesSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/KnownMissingTypesSourceGenerator.java
@@ -41,7 +41,7 @@ import java.util.Set;
                 @Option(
                         key = "known.missing.types.list",
                         description = "A list of types that the AOT analyzer needs to check for existence (comma separated)",
-                        sampleValue = "javax.inject.Inject,io.micronaut.SomeType"
+                        sampleValue = "io.reactivex.Observable,reactor.core.publisher.Flux,kotlinx.coroutines.flow.Flow,io.reactivex.rxjava3.core.Flowable,io.reactivex.rxjava3.core.Observable,io.reactivex.Single,reactor.core.publisher.Mono,io.reactivex.Maybe,io.reactivex.rxjava3.core.Single,io.reactivex.rxjava3.core.Maybe,io.reactivex.Completable,io.reactivex.rxjava3.core.Completable,io.methvin.watchservice.MacOSXListeningWatchService,io.micronaut.core.async.publisher.CompletableFuturePublisher,io.micronaut.core.async.publisher.Publishers.JustPublisher,io.micronaut.core.async.subscriber.Completable"
                 )
         }
 )

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGenerator.java
@@ -50,7 +50,7 @@ import static javax.lang.model.element.Modifier.PUBLIC;
                 @Option(
                         key = "service.types",
                         description = "The list of service types to be scanned (comma separated)",
-                        sampleValue = "io.micronaut.Service1,io.micronaut.Service2"
+                        sampleValue = AbstractStaticServiceLoaderSourceGenerator.DEFAULT_SERVICE_TYPES
                 ),
                 @Option(
                         key = "serviceloading.rejected.impls",


### PR DESCRIPTION
This commit changes the sample values for the "known missing types" and
"service loading" optimizations, so that if the samples are generated,
users get more relevant idea of what should be put as configuration for
those optimizations.