### PR TITLE
Introduce Netty optimization

### DIFF
--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -12,6 +12,7 @@ import io.micronaut.aot.std.sourcegen.GraalVMOptimizationFeatureSourceGenerator
 import io.micronaut.aot.std.sourcegen.JitStaticServiceLoaderSourceGenerator
 import io.micronaut.aot.std.sourcegen.KnownMissingTypesSourceGenerator
 import io.micronaut.aot.std.sourcegen.LogbackConfigurationSourceGenerator
+import io.micronaut.aot.std.sourcegen.NettyPropertiesSourceGenerator
 import io.micronaut.aot.std.sourcegen.PublishersSourceGenerator
 import io.micronaut.aot.std.sourcegen.CachedEnvironmentSourceGenerator
 import io.micronaut.aot.std.sourcegen.YamlPropertySourceGenerator
@@ -52,6 +53,9 @@ class CliTest extends Specification {
                 [KnownMissingTypesSourceGenerator.DESCRIPTION, """known.missing.types.enabled = true
 ${toPropertiesSample(KnownMissingTypesSourceGenerator)}"""],
                 [LogbackConfigurationSourceGenerator.DESCRIPTION, 'logback.xml.to.java.enabled = true'],
+                [NettyPropertiesSourceGenerator.DESCRIPTION, """netty.properties.enabled = true
+${toPropertiesSample(NettyPropertiesSourceGenerator, NettyPropertiesSourceGenerator.MACHINE_ID)}
+${toPropertiesSample(NettyPropertiesSourceGenerator, NettyPropertiesSourceGenerator.PROCESS_ID)}"""],
                 [EnvironmentPropertiesSourceGenerator.DESCRIPTION, 'precompute.environment.properties.enabled = true'],
                 [PublishersSourceGenerator.DESCRIPTION, 'scan.reactive.types.enabled = true'],
                 [AbstractStaticServiceLoaderSourceGenerator.DESCRIPTION, """serviceloading.${runtime}.enabled = true

--- a/aot-core/src/testFixtures/groovy/io/micronaut/aot/core/codegen/AbstractSourceGeneratorSpec.groovy
+++ b/aot-core/src/testFixtures/groovy/io/micronaut/aot/core/codegen/AbstractSourceGeneratorSpec.groovy
@@ -290,6 +290,11 @@ abstract class AbstractSourceGeneratorSpec extends Specification {
             checkedSources = true
             assert generatedSource.contains(expected)
         }
+
+        void doesNotContainSources(String missing) {
+            checkedSources = true
+            assert !generatedSource.contains(missing)
+        }
     }
 
     static String normalize(Object input) {

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/NettyPropertiesSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/NettyPropertiesSourceGenerator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aot.std.sourcegen;
+
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import io.micronaut.aot.core.AOTContext;
+import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.Option;
+import io.micronaut.aot.core.codegen.AbstractCodeGenerator;
+import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.ApplicationContextConfigurer;
+import io.micronaut.core.annotation.NonNull;
+
+import java.util.Random;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.lang.model.element.Modifier.STATIC;
+
+/**
+ * A code generator which is responsible for setting up Netty properties.
+ */
+@AOTModule(
+        id = NettyPropertiesSourceGenerator.ID,
+        description = NettyPropertiesSourceGenerator.DESCRIPTION,
+        options = {
+                @Option(
+                        key = NettyPropertiesSourceGenerator.MACHINE_ID,
+                        description = NettyPropertiesSourceGenerator.MACHINE_ID_DESCRIPTION,
+                        sampleValue = "random"
+                ),
+                @Option(
+                        key = NettyPropertiesSourceGenerator.PROCESS_ID,
+                        description = NettyPropertiesSourceGenerator.PROCESS_ID_DESCRIPTION,
+                        sampleValue = "random"
+                )
+        }
+)
+public class NettyPropertiesSourceGenerator extends AbstractCodeGenerator {
+    public static final String GENERATED_CLASS = "NettyPropertiesAOTContextConfigurer";
+
+    public static final String ID = "netty.properties";
+    public static final String DESCRIPTION = "Defines some Netty system properties when starting the application which optimize startup times.";
+
+    public static final String MACHINE_ID = "netty.machine.id";
+    public static final String MACHINE_ID_DESCRIPTION = "The machine id used by Netty. By default, generates a random value at runtime. Set it to a fixed MAC address to override, or use the value 'netty' to disable the optimization and get it at runtime.";
+
+    public static final String PROCESS_ID = "netty.process.id";
+    public static final String PROCESS_ID_DESCRIPTION = "The process id to use for Netty. Defaults to a random PID at runtime. Set it to a fixed value (not recommended) or use the value 'netty' to disable the optimization and get it at runtime.";
+
+    private static final String RANDOM_VALUE = "random";
+    private static final String DEFAULT_NETTY_BEHAVIOR = "netty";
+
+    @Override
+    public void generate(@NonNull AOTContext context) {
+        context.registerGeneratedSourceFile(context.javaFile(buildConfigurer(context)));
+        context.registerServiceImplementation(ApplicationContextConfigurer.class, GENERATED_CLASS);
+    }
+
+    private TypeSpec buildConfigurer(AOTContext context) {
+        TypeSpec.Builder classBuilder = TypeSpec.classBuilder(GENERATED_CLASS)
+                .addSuperinterface(ApplicationContextConfigurer.class)
+                .addModifiers(PUBLIC);
+        MethodSpec.Builder configure = MethodSpec.methodBuilder("configure")
+                .addModifiers(PUBLIC)
+                .addAnnotation(Override.class)
+                .addParameter(ApplicationContextBuilder.class, "builder");
+        ifOptimizationEnabled(machineIdOptionOf(context), machineId ->
+                defineSystemProperty(classBuilder, configure, "io.netty.machineId", machineId, () -> MethodSpec.methodBuilder("randomMacAddress")
+                        .addModifiers(PRIVATE, STATIC)
+                        .returns(String.class)
+                        .addCode(CodeBlock.builder()
+                                .addStatement("$T rnd = new $T()", Random.class, Random.class)
+                                .addStatement("$T sb = new $T()", StringBuilder.class, StringBuilder.class)
+                                .beginControlFlow("for (int i = 0; i < 6; i++)")
+                                .addStatement("sb.append(String.format(\"%02x\", rnd.nextInt(256)))")
+                                .beginControlFlow("if (i < 5)")
+                                .addStatement("sb.append(\":\")")
+                                .endControlFlow()
+                                .endControlFlow()
+                                .addStatement("return sb.toString()")
+                                .build()
+                        ).build())
+        );
+
+        ifOptimizationEnabled(pidOf(context), pid ->
+                defineSystemProperty(classBuilder, configure, "io.netty.processId", pid, () -> MethodSpec.methodBuilder("randomPid")
+                        .addModifiers(PRIVATE, STATIC)
+                        .returns(String.class)
+                        .addStatement("return String.valueOf(new Random().nextInt(65536))")
+                        .build())
+        );
+        return classBuilder.addMethod(configure.build())
+                .build();
+    }
+
+    private static void ifOptimizationEnabled(String option, Consumer<? super String> consumer) {
+        if (!DEFAULT_NETTY_BEHAVIOR.equals(option)) {
+            consumer.accept(option);
+        }
+    }
+
+    private static void defineSystemProperty(TypeSpec.Builder clazz, MethodSpec.Builder configure, String name, String value, Supplier<MethodSpec> randomizer) {
+        if (RANDOM_VALUE.equals(value)) {
+            MethodSpec methodSpec = randomizer.get();
+            clazz.addMethod(methodSpec);
+            configure.addStatement("System.setProperty($S, $L)", name, methodSpec.name + "()");
+        } else {
+            configure.addStatement("System.setProperty($S, $S)", name, value);
+        }
+    }
+
+    private static String pidOf(AOTContext context) {
+        return context.getConfiguration().optionalString(PROCESS_ID, RANDOM_VALUE);
+    }
+
+    private static String machineIdOptionOf(AOTContext context) {
+        return context.getConfiguration().optionalString(MACHINE_ID, RANDOM_VALUE);
+    }
+
+}

--- a/aot-std-optimizers/src/main/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator
+++ b/aot-std-optimizers/src/main/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator
@@ -8,3 +8,4 @@ io.micronaut.aot.std.sourcegen.CachedEnvironmentSourceGenerator
 io.micronaut.aot.std.sourcegen.LogbackConfigurationSourceGenerator
 io.micronaut.aot.std.sourcegen.GraalVMOptimizationFeatureSourceGenerator
 io.micronaut.aot.std.sourcegen.DeduceEnvironmentSourceGenerator
+io.micronaut.aot.std.sourcegen.NettyPropertiesSourceGenerator

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/NettyPropertiesSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/NettyPropertiesSourceGeneratorTest.groovy
@@ -1,0 +1,125 @@
+package io.micronaut.aot.std.sourcegen
+
+import io.micronaut.aot.core.AOTCodeGenerator
+import io.micronaut.aot.core.codegen.AbstractSourceGeneratorSpec
+
+class NettyPropertiesSourceGeneratorTest extends AbstractSourceGeneratorSpec {
+
+    @Override
+    AOTCodeGenerator newGenerator() {
+        new NettyPropertiesSourceGenerator()
+    }
+
+    def "generates random Netty system properties"() {
+        when:
+        generate()
+
+        then:
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            hasClass(NettyPropertiesSourceGenerator.GENERATED_CLASS) {
+                containingSources """
+    System.setProperty("io.netty.machineId", randomMacAddress());
+    System.setProperty("io.netty.processId", randomPid());
+"""
+                containingSources randomMacAddress()
+                containingSources randomPid()
+            }
+        }
+    }
+
+    def "can disable PID randomization"() {
+        when:
+        props.put(NettyPropertiesSourceGenerator.PROCESS_ID, "netty")
+        generate()
+
+        then:
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            hasClass(NettyPropertiesSourceGenerator.GENERATED_CLASS) {
+                containingSources """
+    System.setProperty("io.netty.machineId", randomMacAddress());
+"""
+                containingSources randomMacAddress()
+                doesNotContainSources randomPid()
+            }
+        }
+    }
+
+    def "can disable machine id randomization"() {
+        when:
+        props.put(NettyPropertiesSourceGenerator.MACHINE_ID, "netty")
+        generate()
+
+        then:
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            hasClass(NettyPropertiesSourceGenerator.GENERATED_CLASS) {
+                containingSources """
+    System.setProperty("io.netty.processId", randomPid());
+"""
+                containingSources randomPid()
+                doesNotContainSources randomMacAddress()
+            }
+        }
+    }
+
+    def "can generate a hardcoded machine id"() {
+        when:
+        props.put(NettyPropertiesSourceGenerator.MACHINE_ID, "ab:cd:ef:00:11:22")
+        props.put(NettyPropertiesSourceGenerator.PROCESS_ID, "netty")
+        generate()
+
+        then:
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            hasClass(NettyPropertiesSourceGenerator.GENERATED_CLASS) {
+                containingSources """
+    System.setProperty("io.netty.machineId", "ab:cd:ef:00:11:22");
+"""
+                doesNotContainSources randomMacAddress()
+                doesNotContainSources randomPid()
+            }
+        }
+    }
+
+    def "can generate a hardcoded process id"() {
+        when:
+        props.put(NettyPropertiesSourceGenerator.PROCESS_ID, "85600")
+        props.put(NettyPropertiesSourceGenerator.MACHINE_ID, "netty")
+
+        generate()
+
+        then:
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            hasClass(NettyPropertiesSourceGenerator.GENERATED_CLASS) {
+                containingSources """
+    System.setProperty("io.netty.processId", "85600");
+"""
+                doesNotContainSources randomMacAddress()
+                doesNotContainSources randomPid()
+            }
+        }
+    }
+
+    private static String randomMacAddress() {
+        """private static String randomMacAddress() {
+    Random rnd = new Random();
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 6; i++) {
+      sb.append(String.format("%02x", rnd.nextInt(256)));
+      if (i < 5) {
+        sb.append(":");
+      }
+    }
+    return sb.toString();
+  }"""
+    }
+
+    private static String randomPid() {
+        """private static String randomPid() {
+    return String.valueOf(new Random().nextInt(65536));
+  }"""
+    }
+}


### PR DESCRIPTION
This commit introduces a new optimization (id `netty.properties`) which
allows setting the `io.netty.machineId` and `io.netty.processId` system
properties before Netty reads them. Those system properties are used by
Netty in a composite key which is used to compute a channel id.

By default, if the system properties are not set, Netty will compute them,
which involves scanning MAC addresses or using JMX to get the current process
PID, which is expensive (up to 20ms on my machine).

This optimization, if enabled, overrides the system properties at startup,
by generating _random values at application startup_ for both the MAC
address and the PID. This is the default behavior of Netty when it cannot,
for some reason, infer those, so it should be safe.

Alternatively, the optimization allows for setting _constant_ values, which
is probably not recommended unless the distribution binary is bound to
a particular machine.