### PR TITLE
Fixed exception with YamlGenerator when use list with placeholders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,18 +1,19 @@
 # Auto detect text files and perform LF normalization
-*        text=auto
+*        text=lf
 
-*.java   text
-*.html   text
-*.kt     text
-*.kts    text
-*.md     text diff=markdown
+*.java   text eol=lf
+*.groovy text eol=lf
+*.html   text eol=lf
+*.kt     text eol=lf
+*.kts    text eol=lf
+*.md     text diff=markdown eol=lf
 *.py     text diff=python executable
 *.pl     text diff=perl executable
 *.pm     text diff=perl
-*.css    text diff=css
-*.js     text
-*.sql    text
-*.q      text
+*.css    text diff=css eol=lf
+*.js     text eol=lf
+*.sql    text eol=lf
+*.q      text eol=lf
 
 *.sh     text eol=lf
 gradlew  text eol=lf

--- a/aot-core/src/main/java/io/micronaut/aot/core/codegen/MapGenerator.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/codegen/MapGenerator.java
@@ -97,7 +97,7 @@ public class MapGenerator {
         } else {
             listMethod.addStatement("$T result = new $T<>($L)", List.class, ArrayList.class, value.size());
             for (Object o : value) {
-                listMethod.addStatement("result.add(" + convertValueToSource(o, builder) + ")");
+                listMethod.addCode("result.add($L);\n", convertValueToSource(o, builder));
             }
             listMethod.addStatement("return result");
         }

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/YamlPropertySourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/YamlPropertySourceGeneratorTest.groovy
@@ -49,10 +49,13 @@ import java.util.Map;
 public class Test_configStaticPropertySource extends MapPropertySource {
   Test_configStaticPropertySource() {
     super("test-config", new HashMap() {{
+        put("my.prop1", "val1");
+        put("my.prop2", "val2");
         put("micronaut.application.name", "demoApp");
         put("micronaut.server.port", 8181);
         put("micronaut.server.cors.enabled", true);
         put("micronaut.security.intercept-url-map", list0());
+        put("otel.exclusions", list5());
         }});
   }
 
@@ -84,6 +87,14 @@ public class Test_configStaticPropertySource extends MapPropertySource {
     List result = new ArrayList<>(2);
     result.add(map1());
     result.add(map3());
+    return result;
+  }
+
+  private static List list5() {
+    List result = new ArrayList<>(3);
+    result.add("\${my.prop1}");
+    result.add("\${my.prop2}");
+    result.add("fixed-value");
     return result;
   }
 

--- a/aot-std-optimizers/src/test/resources/test-config.yml
+++ b/aot-std-optimizers/src/test/resources/test-config.yml
@@ -1,3 +1,7 @@
+my:
+  prop1: val1
+  prop2: val2
+
 micronaut:
   application:
     name: demoApp
@@ -17,3 +21,8 @@ micronaut:
         http-method: GET
         access:
           - isAnonymous()
+otel:
+  exclusions:
+    - ${my.prop1}
+    - ${my.prop2}
+    - fixed-value

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ githubSlug=micronaut-projects/micronaut-aot
 developers=Graeme Rocher
 
 # Micronaut core branch for BOM pull requests
-githubCoreBranch=3.5.x
+githubCoreBranch=3.8.x
 
 bomProperty=micronautAotVersion
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Now you can't set placeholders in list property like this:
```yaml
otel:
  exclusions:
    - ${my.prop1}
    - ${my.prop2}
```
You will see this exception:
```
Caused by: java.lang.IllegalArgumentException: index 1 for '${' not in range (received 0 arguments)
	at com.squareup.javapoet.Util.checkArgument(Util.java:53)
	at com.squareup.javapoet.CodeBlock$Builder.add(CodeBlock.java:287)
	at com.squareup.javapoet.CodeBlock$Builder.addStatement(CodeBlock.java:402)
	at com.squareup.javapoet.MethodSpec$Builder.addStatement(MethodSpec.java:525)
	at io.micronaut.aot.core.codegen.MapGenerator.generateListMethod(MapGenerator.java:100)
	at io.micronaut.aot.core.codegen.MapGenerator.convertValueToSource(MapGenerator.java:61)
	at io.micronaut.aot.core.codegen.MapGenerator.generateMap(MapGenerator.java:44)
	at io.micronaut.aot.std.sourcegen.MapPropertySourceGenerator.generate(MapPropertySourceGenerator.java:77)
```

This PR fixes bug.

Also fixed project to run it on Windows