### PR TITLE
Add a BOM

### DIFF
--- a/aot-api/build.gradle.kts
+++ b/aot-api/build.gradle.kts
@@ -20,5 +20,5 @@ plugins {
 description = "Micronaut AOT API, for integration in build/CLI tools"
 
 dependencies {
-    implementation(projects.aotCore)
+    implementation(projects.micronautAotCore)
 }

--- a/aot-bom/build.gradle.kts
+++ b/aot-bom/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("io.micronaut.build.internal.bom")
+}
+
+val isGreaterThan2_0 = provider {
+    version.toString()
+        .split('.')
+        .let { it[0].toInt() >= 2 && (it[1].toInt() > 0) }
+}
+
+micronautBuild {
+    binaryCompatibility.enabled.set(isGreaterThan2_0)
+}

--- a/aot-cli/build.gradle.kts
+++ b/aot-cli/build.gradle.kts
@@ -28,17 +28,17 @@ val testAotRuntime by configurations.creating {
 
 dependencies {
     implementation(platform(mn.micronaut.core.bom))
-    implementation(projects.aotApi)
+    implementation(projects.micronautAotApi)
     implementation(mnPicocli.picocli)
 
     testImplementation(mnTest.micronaut.test.spock)
-    testImplementation(projects.aotCore)
-    testImplementation(projects.aotStdOptimizers)
+    testImplementation(projects.micronautAotCore)
+    testImplementation(projects.micronautAotStdOptimizers)
     testImplementation(mn.micronaut.core)
 
     testAotRuntime(mn.micronaut.context)
     testAotRuntime(mn.micronaut.inject)
-    testAotRuntime(projects.aotStdOptimizers)
+    testAotRuntime(projects.micronautAotStdOptimizers)
 }
 
 tasks.named<Test>("test") {

--- a/aot-std-optimizers/build.gradle.kts
+++ b/aot-std-optimizers/build.gradle.kts
@@ -26,13 +26,13 @@ dependencies {
     compileOnlyApi(mn.micronaut.context)
     compileOnlyApi(mn.micronaut.core.reactive)
 
-    compileOnlyApi(projects.aotCore)
+    compileOnlyApi(projects.micronautAotCore)
     compileOnly(mn.logback.classic)
 
-    testImplementation(testFixtures(projects.aotCore))
+    testImplementation(testFixtures(projects.micronautAotCore))
     testImplementation(mn.micronaut.context)
     testImplementation(mn.micronaut.core.reactive)
-    testCompileOnly(projects.aotCore)
+    testCompileOnly(projects.micronautAotCore)
     testImplementation(mn.logback.classic)
     testRuntimeOnly(mn.snakeyaml)
 }

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/PublishersSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/PublishersSourceGeneratorTest.groovy
@@ -46,7 +46,7 @@ import java.util.Arrays;
 public class PublishersOptimizationsLoader implements StaticOptimizations.Loader<PublishersOptimizations> {
   @Override
   public PublishersOptimizations load() {
-    return new PublishersOptimizations(Arrays.asList(), Arrays.asList(CompletableFuturePublisher.class, Publishers.JustPublisher.class), Arrays.asList(Completable.class));
+    return new PublishersOptimizations(Arrays.asList(CompletableFuturePublisher.class, Publishers.JustPublisher.class, Completable.class), Arrays.asList(CompletableFuturePublisher.class, Publishers.JustPublisher.class), Arrays.asList(Completable.class));
   }
 }"""
                 compiles()

--- a/build-logic/src/main/groovy/io.micronaut.build.internal.aot-project.gradle
+++ b/build-logic/src/main/groovy/io.micronaut.build.internal.aot-project.gradle
@@ -24,9 +24,6 @@ repositories {
     maven { setUrl("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
 }
 
-group = "io.micronaut.aot"
-version = projectVersion
-
 micronautBuild {
     enableProcessing = false
     enableBom = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 projectVersion=2.0.0-SNAPSHOT
+projectGroup=io.micronaut.aot
 micronautVersion=4.0.0-SNAPSHOT
 micronautTestVersion=4.0.0-SNAPSHOT
 groovyVersion=4.0.6

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,13 +9,14 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "6.2.2"
+    id("io.micronaut.build.shared.settings") version "6.3.3"
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 rootProject.name = "aot-parent"
 
+include("aot-bom")
 include("aot-core")
 include("aot-std-optimizers")
 include("aot-api")
@@ -25,4 +26,5 @@ configure<io.micronaut.build.MicronautBuildSettingsExtension> {
     addSnapshotRepository()
     importMicronautCatalog()
     importMicronautCatalog("micronaut-picocli")
+    useStandardizedProjectNames.set(true)
 }


### PR DESCRIPTION
This commit adds a BOM module for consistency with other Micronaut modules. It is worth noting, however, that the BOM is unlikely to be added in any user build, since AOT is a special module which is integrated by build tools.

This commit also upgrades to the latest build plugins and enables standardized project names.

Fixes #179