### PR TITLE
Fix duplicate logging when converting logback to Java

### DIFF
--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/Logback14GeneratorHelper.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/Logback14GeneratorHelper.java
@@ -335,7 +335,7 @@ class Logback14GeneratorHelper {
             }
         };
         visitor.visit(model);
-        codeBuilder.addStatement(CodeBlock.of("return $T.NEUTRAL", Configurator.ExecutionStatus.class));
+        codeBuilder.addStatement(CodeBlock.of("return $T.DO_NOT_INVOKE_NEXT_IF_ANY", Configurator.ExecutionStatus.class));
         return MethodSpec.methodBuilder("configure")
                 .addModifiers(Modifier.PUBLIC)
                 .returns(Configurator.ExecutionStatus.class)

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGeneratorTest.groovy
@@ -78,7 +78,7 @@ public class StaticLogbackConfiguration implements Configurator {
     io_micronaut_core_optim_staticoptimizations.addAppender(stdout);
     io_micronaut_core_io_service_softserviceloader.addAppender(stdout);
     io_micronaut_aot.addAppender(stdout);
-    return Configurator.ExecutionStatus.NEUTRAL;
+    return Configurator.ExecutionStatus.DO_NOT_INVOKE_NEXT_IF_ANY;
   }
 
   public void setContext(Context context) {
@@ -169,7 +169,7 @@ public class StaticLogbackConfiguration implements Configurator {
     _rootLogger.setLevel(Level.INFO);
     _rootLogger.addAppender(file);
     org_acme.addAppender(console);
-    return Configurator.ExecutionStatus.NEUTRAL;
+    return Configurator.ExecutionStatus.DO_NOT_INVOKE_NEXT_IF_ANY;
   }
 
   public void setContext(Context context) {
@@ -262,7 +262,7 @@ public class StaticLogbackConfiguration implements Configurator {
     Logger _rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
     _rootLogger.setLevel(Level.INFO);
     _rootLogger.addAppender(file);
-    return Configurator.ExecutionStatus.NEUTRAL;
+    return Configurator.ExecutionStatus.DO_NOT_INVOKE_NEXT_IF_ANY;
   }
 
   public void setContext(Context context) {
@@ -348,7 +348,7 @@ public class StaticLogbackConfiguration implements Configurator {
     Logger _rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
     _rootLogger.setLevel(Level.INFO);
     _rootLogger.addAppender(console);
-    return Configurator.ExecutionStatus.NEUTRAL;
+    return Configurator.ExecutionStatus.DO_NOT_INVOKE_NEXT_IF_ANY;
   }
 
   public void setContext(Context context) {


### PR DESCRIPTION
This commit fixes the logback to Java converter. While conversion worked, it was actually duplicating logs because the return value of the configurator was wrong and that it triggered the creation of additional configuration from logback.