### PR TITLE
Improve documentation

### DIFF
--- a/aot-core/src/main/java/io/micronaut/aot/core/Runtime.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/Runtime.java
@@ -19,6 +19,16 @@ package io.micronaut.aot.core;
  * The targetted type of runtime.
  */
 public enum Runtime {
-    JIT,
-    NATIVE
+    JIT("JIT"),
+    NATIVE("native");
+
+    private final String displayName;
+
+    Runtime(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
 }

--- a/aot-std-optimizers/build.gradle.kts
+++ b/aot-std-optimizers/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.plugins.internal.JvmPluginsHelper
+
 /*
  * Copyright 2017-2021 original authors
  *
@@ -35,4 +37,38 @@ dependencies {
     testCompileOnly(projects.micronautAotCore)
     testImplementation(mnLogging.logback.classic)
     testRuntimeOnly(mn.snakeyaml)
+}
+
+val configPropsGenerator by sourceSets.creating {
+}
+
+dependencies {
+    "configPropsGeneratorImplementation"(project)
+    "configPropsGeneratorRuntimeOnly"(projects.micronautAotCore)
+    "configPropsGeneratorRuntimeOnly"(mn.micronaut.context)
+    "configPropsGeneratorRuntimeOnly"(mnLogging.slf4j.simple)
+}
+
+val configFile = layout.buildDirectory.file("generated-config/standard-optimizers.adoc")
+
+val generateConfigProps = tasks.register<JavaExec>("generateConfigProps") {
+    classpath = configPropsGenerator.runtimeClasspath
+    mainClass.set("io.micronaut.aot.config.ConfigPropsGenerator")
+    args(configFile.map { it.asFile.absolutePath }.get())
+    doFirst {
+        configFile.map { it.asFile.absoluteFile.parentFile }.get().mkdirs()
+    }
+}
+
+configurations {
+    individualConfigurationPropertiesElements {
+        outgoing.artifact(configFile) {
+            builtBy(generateConfigProps)
+        }
+    }
+    configurationPropertiesElements {
+        outgoing.artifact(configFile) {
+            builtBy(generateConfigProps)
+        }
+    }
 }

--- a/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
+++ b/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aot.config;
+
+import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.Option;
+import io.micronaut.aot.core.Runtime;
+import io.micronaut.aot.core.config.SourceGeneratorLoader;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public class ConfigPropsGenerator {
+    public static void main(String[] args) throws IOException {
+        if (args.length != 1) {
+            throw new IllegalArgumentException("A single argument, the path to the output file, is expected");
+        }
+        try (var writer = new PrintWriter(Files.newBufferedWriter(Path.of(args[0]), StandardCharsets.UTF_8))) {
+            var codegenerators = Stream.concat(
+                    SourceGeneratorLoader.list(Runtime.JIT).stream(),
+                    SourceGeneratorLoader.list(Runtime.NATIVE).stream()
+                ).distinct()
+                .toList();
+            writer.println("WARNING: These are not configuration properties to add in your regular Micronaut configuration files," +
+                           "but properties to be added to the Micronaut AOT configuration, via your build plugin." +
+                           "Please refer to the appropriate Maven or Gradle plugin for more details.");
+            writer.println();
+            for (AOTModule module : codegenerators) {
+                writer.println("=== Module " + module.id());
+                writer.println();
+                writer.print("This module is available ");
+                var runtimes = module.enabledOn();
+                if (runtimes.length == 1) {
+                    writer.println("in " + runtimes[0].displayName() + " mode.");
+                } else {
+                    writer.println("in JIT and native modes.");
+                }
+                writer.println();
+                writer.println(".Configuration Properties for " + module.id());
+                writer.println("[cols=\"1,3,3\"]");
+                writer.println("|===");
+                writer.println("|Property|Description|Example value");
+                writer.println("|" + module.id() + ".enabled|Enables the " + module.description() + " optimization|true");
+                for (Option option : module.options()) {
+                    // Add 0-width space so that text wrapping works
+                    var sample = option.sampleValue().replace(",", "\u200B");
+                    writer.println("|" + option.key() + "|" + option.description() + "|" + sample);
+                }
+                writer.println("|===");
+            }
+        }
+    }
+}

--- a/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
+++ b/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
@@ -57,11 +57,11 @@ public class ConfigPropsGenerator {
                 writer.println("[cols=\"1,3,3\"]");
                 writer.println("|===");
                 writer.println("|Property|Description|Example value");
-                writer.println("|" + module.id() + ".enabled|Enables the " + module.description() + " optimization|true");
+                writer.println("| `" + module.id() + ".enabled` |Enables the " + module.description() + " optimization|`true`");
                 for (Option option : module.options()) {
                     // Add 0-width space so that text wrapping works
                     var sample = option.sampleValue().replace(",", ",\u200B");
-                    writer.println("|" + option.key() + "|" + option.description() + "|" + sample);
+                    writer.println("| `" + option.key() + "` |" + option.description() + "| `" + sample + "`");
                 }
                 writer.println("|===");
             }

--- a/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
+++ b/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
@@ -60,7 +60,7 @@ public class ConfigPropsGenerator {
                 writer.println("|" + module.id() + ".enabled|Enables the " + module.description() + " optimization|true");
                 for (Option option : module.options()) {
                     // Add 0-width space so that text wrapping works
-                    var sample = option.sampleValue().replace(",", "\u200B");
+                    var sample = option.sampleValue().replace(",", ",\u200B");
                     writer.println("|" + option.key() + "|" + option.description() + "|" + sample);
                 }
                 writer.println("|===");

--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -1,3 +1,6 @@
+WARNING: Unlike other Micronaut modules, Micronaut AOT is not a dependency which needs to be added to your application: it's a framework which requires integration with your build process: it is typically aimed at being integrated into build tool plugins. If you are looking into documentation about how to configure Micronaut AOT, you should look into the corresponding build tool documentation.
+Micronaut AOT support is implemented by the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/#_micronaut_aot_plugin[Micronaut Gradle plugin] and https://micronaut-projects.github.io/micronaut-maven-plugin/latest/examples/aot.html[Micronaut Maven plugin].
+
 Micronaut AOT is a framework which implements _ahead-of-time_ (AOT) optimizations for Micronaut application and libraries.
 Those optimizations consist of computing _at build time_ things which would normally be done at runtime.
 This includes, but is not limited to:
@@ -7,6 +10,3 @@ This includes, but is not limited to:
 - performing substitution of classes with "optimized" versions for a particular environment
 
 Micronaut AOT can generate specific optimizations for different environments, in particular, it can make a difference between optimizations needed in JIT mode (traditional JVM applications) and native mode (application compiled with GraalVM `native-image`).
-
-WARNING: Unlike other Micronaut modules, Micronaut AOT is not a dependency which needs to be added to your application: it's a framework which requires integration with your build process: it is typically aimed at being integrated into build tool plugins.
-Integration with Micronaut AOT is implemented by the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/#_micronaut_aot_plugin[Micronaut Gradle plugin] and https://micronaut-projects.github.io/micronaut-maven-plugin/latest/examples/aot.html[Micronaut Maven plugin].

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -1,7 +1,5 @@
 == Applicability
 
-NOTE: Micronaut AOT is an experimental project. Use at your own risk.
-
 The goal of Micronaut AOT is to create an optimized "binary" for a particular deployment environment.
 It is **not** to make development experience faster: because build time optimizations require deep analysis of the application, it will actually make the local development slower if you use optimized binaries.
 

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -7,6 +7,11 @@ It is **not** to make development experience faster: because build time optimiza
 
 You should consider Micronaut AOT similarly to what GraalVM's `native-image` tool is: a "compiler" which generates a _different_ application, aimed at a particular _runtime_. That is, depending on the optimizations which are enabled, a binary optimized by AOT may, or may not, work in a specific deployment environment.
 
+As a consequence, it is recommended to build your Micronaut AOT optimized application on the same environment as the deployment one.
+Please refer to the documentation of your build tool for configuration options.
+
+The following documentation is for users who want to implement their own AOT optimizers.
+
 == Micronaut AOT projects
 
 The Micronaut AOT project consists of 4 main modules:


### PR DESCRIPTION
This commit retrofits the "configuration properties" page to include documentation of the standard optimizations in the Micronaut AOT documentation page.

Here's what is rendered for the configuration properties page now:

![image](https://github.com/micronaut-projects/micronaut-aot/assets/316357/8bed475a-5b3b-4069-9f9b-f3cbc35b80c3)
