### PR TITLE
Fix AOT for GraalVM 22

### DIFF
--- a/aot-core/src/main/java/io/micronaut/aot/core/AOTContext.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/AOTContext.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -116,6 +117,12 @@ public interface AOTContext {
     void registerClassNeededAtCompileTime(@NonNull Class<?> clazz);
 
     /**
+     * Registers a type as a requiring initialization at build time.
+     * @param className the type
+     */
+    void registerBuildTimeInit(@NonNull String className);
+
+    /**
      * Generates a java file spec.
      * @param typeSpec the type spec of the main class
      * @return a java file
@@ -165,4 +172,16 @@ public interface AOTContext {
      */
     @NonNull
     Runtime getRuntime();
+
+    /**
+     * Returns the set of classes which require build time initialization
+     * @return the set of classes needing build time init
+     */
+    Set<String> getBuildTimeInitClasses();
+
+    /**
+     * Performs actions which have to be done as late as possible during
+     * source generation.
+     */
+    void finish();
 }

--- a/aot-core/src/main/java/io/micronaut/aot/core/codegen/AbstractSingleClassFileGenerator.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/codegen/AbstractSingleClassFileGenerator.java
@@ -34,6 +34,8 @@ public abstract class AbstractSingleClassFileGenerator extends AbstractCodeGener
         this.context = context;
         JavaFile javaFile = generate();
         context.registerGeneratedSourceFile(javaFile);
+        context.registerBuildTimeInit(javaFile.packageName + "." + javaFile.typeSpec.name);
+        context.registerBuildTimeInit(javaFile.packageName + "." + javaFile.typeSpec.name + "$1");
     }
 
     protected final AOTContext getContext() {

--- a/aot-core/src/main/java/io/micronaut/aot/core/codegen/ApplicationContextConfigurerGenerator.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/codegen/ApplicationContextConfigurerGenerator.java
@@ -69,6 +69,7 @@ public class ApplicationContextConfigurerGenerator extends AbstractCodeGenerator
         optimizedEntryPoint.addStaticBlock(staticInitializer.build());
         context.registerGeneratedSourceFile(context.javaFile(optimizedEntryPoint.build()));
         context.registerServiceImplementation(ApplicationContextConfigurer.class, CUSTOMIZER_CLASS_NAME);
+        context.finish();
     }
 
     private void addDiagnostics(AOTContext context, TypeSpec.Builder optimizedEntryPoint) {

--- a/aot-core/src/main/java/io/micronaut/aot/core/codegen/DelegatingSourceGenerationContext.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/codegen/DelegatingSourceGenerationContext.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -111,6 +112,11 @@ public abstract class DelegatingSourceGenerationContext implements AOTContext {
     }
 
     @Override
+    public void registerBuildTimeInit(String className) {
+        delegate.registerBuildTimeInit(className);
+    }
+
+    @Override
     @NonNull
     public JavaFile javaFile(TypeSpec typeSpec) {
         return delegate.javaFile(typeSpec);
@@ -143,5 +149,15 @@ public abstract class DelegatingSourceGenerationContext implements AOTContext {
     @NonNull
     public Runtime getRuntime() {
         return delegate.getRuntime();
+    }
+
+    @Override
+    public Set<String> getBuildTimeInitClasses() {
+        return delegate.getBuildTimeInitClasses();
+    }
+
+    @Override
+    public void finish() {
+        delegate.finish();
     }
 }

--- a/aot-core/src/testFixtures/groovy/io/micronaut/aot/core/codegen/AbstractSourceGeneratorSpec.groovy
+++ b/aot-core/src/testFixtures/groovy/io/micronaut/aot/core/codegen/AbstractSourceGeneratorSpec.groovy
@@ -63,9 +63,10 @@ abstract class AbstractSourceGeneratorSpec extends Specification {
 
     abstract AOTCodeGenerator newGenerator()
 
-    void generate() {
+    final void generate() {
         def sourceGenerator = newGenerator()
         sourceGenerator.generate(context)
+        context.finish()
         def sources = context.getGeneratedJavaFiles().collectEntries([:]) {
             def writer = new StringWriter()
             it.writeTo(writer)

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGenerator.java
@@ -28,6 +28,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Generates the GraalVM configuration file which is going to configure
@@ -35,33 +36,47 @@ import java.util.List;
  * the optimized entry point at build time.
  */
 @AOTModule(
-        id = GraalVMOptimizationFeatureSourceGenerator.ID,
-        description = GraalVMOptimizationFeatureSourceGenerator.DESCRIPTION,
-        options = {
-                @Option(
-                        key = "service.types",
-                        description = "The list of service types to be scanned (comma separated)",
-                        sampleValue = "io.micronaut.Service1,io.micronaut.Service2"
-                )
-        },
-        enabledOn = Runtime.NATIVE
+    id = GraalVMOptimizationFeatureSourceGenerator.ID,
+    description = GraalVMOptimizationFeatureSourceGenerator.DESCRIPTION,
+    options = {
+        @Option(
+            key = "service.types",
+            description = "The list of service types to be scanned (comma separated)",
+            sampleValue = "io.micronaut.Service1,io.micronaut.Service2"
+        )
+    },
+    enabledOn = Runtime.NATIVE
 )
 public class GraalVMOptimizationFeatureSourceGenerator extends AbstractCodeGenerator {
     public static final String ID = "graalvm.config";
-    public static final String DESCRIPTION = "Generates GraalVM configuration files required to load the AOT optimizations";
+    public static final String DESCRIPTION =
+        "Generates GraalVM configuration files required to load the AOT optimizations";
     private static final String NEXT_LINE = " \\";
 
-    private static final Option OPTION = MetadataUtils.findOption(GraalVMOptimizationFeatureSourceGenerator.class, "service.types");
+    private static final Option OPTION =
+        MetadataUtils.findOption(GraalVMOptimizationFeatureSourceGenerator.class, "service.types");
 
     @Override
     public void generate(@NonNull AOTContext context) {
         List<String> serviceTypes = context.getConfiguration().stringList(OPTION.key());
-        String path = "META-INF/native-image/" + context.getPackageName() + "/native-image.properties";
+        String path =
+            "META-INF/native-image/" + context.getPackageName() + "/native-image.properties";
         context.registerGeneratedResource(path, propertiesFile -> {
             try (PrintWriter wrt = new PrintWriter(new FileWriter(propertiesFile))) {
                 wrt.print("Args=");
-                wrt.println("--initialize-at-build-time=" + context.getPackageName() + "." + ApplicationContextConfigurerGenerator.CUSTOMIZER_CLASS_NAME + NEXT_LINE);
-                if (context.getConfiguration().isFeatureEnabled(NativeStaticServiceLoaderSourceGenerator.ID)) {
+                wrt.println("--initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer$1" + NEXT_LINE);
+                wrt.println("     --initialize-at-build-time=" + context.getPackageName() + "." +
+                            ApplicationContextConfigurerGenerator.CUSTOMIZER_CLASS_NAME +
+                            NEXT_LINE);
+                var buildTimeInit = context.getBuildTimeInitClasses()
+                    .stream()
+                    .map(clazz -> "     --initialize-at-build-time=" + clazz)
+                    .collect(Collectors.joining(NEXT_LINE + "\n"));
+                if (!buildTimeInit.isEmpty()) {
+                    wrt.println(buildTimeInit);
+                }
+                if (context.getConfiguration()
+                    .isFeatureEnabled(NativeStaticServiceLoaderSourceGenerator.ID)) {
                     for (int i = 0; i < serviceTypes.size(); i++) {
                         String serviceType = serviceTypes.get(i);
                         wrt.print("     -H:ServiceLoaderFeatureExcludeServices=" + serviceType);

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGeneratorTest.groovy
@@ -18,7 +18,8 @@ class GraalVMOptimizationFeatureSourceGeneratorTest extends AbstractSourceGenera
         assertThatGeneratedSources {
             doesNotCreateInitializer()
             generatesMetaInfResource("native-image/$packageName/native-image.properties", """
-Args=--initialize-at-build-time=io.micronaut.test.AOTApplicationContextConfigurer \\
+Args=--initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer\$1 \\
+     --initialize-at-build-time=io.micronaut.test.AOTApplicationContextConfigurer \\
 """)
         }
     }
@@ -32,7 +33,8 @@ Args=--initialize-at-build-time=io.micronaut.test.AOTApplicationContextConfigure
         assertThatGeneratedSources {
             doesNotCreateInitializer()
             generatesMetaInfResource("native-image/$packageName/native-image.properties", """
-Args=--initialize-at-build-time=io.micronaut.test.AOTApplicationContextConfigurer \\
+Args=--initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer\$1 \\
+     --initialize-at-build-time=io.micronaut.test.AOTApplicationContextConfigurer \\
      -H:ServiceLoaderFeatureExcludeServices=A \\
      -H:ServiceLoaderFeatureExcludeServices=B \\
      -H:ServiceLoaderFeatureExcludeServices=C


### PR DESCRIPTION
This commit updates how Micronaut AOT generates code for GraalVM 22. In 22, the new default is to forbid build time initialization of classes. Each class which is initialized at build time has to be explicitly declared as such. This commit makes it so that classes we generate and know are initialized at build time are added to the `--initialize-at-build-time` option.

While this fixes a lot of cases, we cannot, unfortunately, kwow upfront all the dependencies of the types we initialize at build time, which may _also_ need build time initialization. This means that in some cases, users will have to explicitly add some types to the list (e.g via a `buildArg` in the native binaries Gradle extension).

Ideally, we should move AOT off build time initialization. However, this is not currently doable, since precisely Micronaut Core and optimization registration is designed to use static fields. An option would be to use service loading instead, but it's a breaking change, and that would remove the ability to have a service loading optimization. While removing the service loading optimization may not be an issue for native, it is, however, a problem for JIT optimizations.

There's therefore no good solution that I'm aware of to this problem.

Note: this problem was unnoticed because we don't have tests which try to build a native image with AOT optimizations on latest GraalVM. It would be good to have such tests somewhere. /cc @fniephaus