### PR TITLE
Support setting status listener for logback generator

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@v1.2.3
+        uses: graalvm/setup-graalvm@v1.2.4
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGeneratorTest.groovy
@@ -46,6 +46,7 @@ import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.Configurator;
 import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.Context;
+import ch.qos.logback.core.status.OnErrorConsoleStatusListener;
 import ch.qos.logback.core.status.Status;
 import java.lang.String;
 import java.lang.Throwable;
@@ -54,6 +55,10 @@ public class StaticLogbackConfiguration implements Configurator {
   private Context context;
 
   public Configurator.ExecutionStatus configure(LoggerContext loggerContext) {
+    OnErrorConsoleStatusListener statuslistener = new OnErrorConsoleStatusListener();
+    loggerContext.getStatusManager().add(statuslistener);
+    statuslistener.setContext(context);
+    statuslistener.start();
     ConsoleAppender stdout = new ConsoleAppender();
     stdout.setWithJansi(true);
     PatternLayoutEncoder encoder = new PatternLayoutEncoder();

--- a/aot-std-optimizers/src/test/resources/logback-test1.xml
+++ b/aot-std-optimizers/src/test/resources/logback-test1.xml
@@ -1,5 +1,7 @@
 <configuration>
 
+    <statusListener class="ch.qos.logback.core.status.OnErrorConsoleStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <withJansi>true</withJansi>
         <encoder>


### PR DESCRIPTION
Adds support for setting target, like here:
```xml
    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
        <target>System.err</target>
        <encoder>
            <pattern>%-5level %date{ISO8601, UTC} %X{opc-request-id} [%thread] %logger: %message%n</pattern>
        </encoder>
    </appender>
```