### PR TITLE
Add fix for native image properties

### DIFF
--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGenerator.java
@@ -51,7 +51,7 @@ public class GraalVMOptimizationFeatureSourceGenerator extends AbstractCodeGener
     public static final String ID = "graalvm.config";
     public static final String DESCRIPTION =
         "Generates GraalVM configuration files required to load the AOT optimizations";
-    private static final String NEXT_LINE = " \\";
+    private static final String NEXT_LINE = " \\\n     ";
 
     private static final Option OPTION =
         MetadataUtils.findOption(GraalVMOptimizationFeatureSourceGenerator.class, "service.types");
@@ -63,27 +63,20 @@ public class GraalVMOptimizationFeatureSourceGenerator extends AbstractCodeGener
         context.registerGeneratedResource(path, propertiesFile -> {
             try (PrintWriter wrt = new PrintWriter(new FileWriter(propertiesFile))) {
                 wrt.print("Args=");
-                wrt.println("--initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer$1" + NEXT_LINE);
-                wrt.println("     --initialize-at-build-time=" + context.getPackageName() + "." +
-                    ApplicationContextConfigurerGenerator.CUSTOMIZER_CLASS_NAME +
-                    NEXT_LINE);
-                var buildTimeInit = context.getBuildTimeInitClasses()
-                    .stream()
-                    .map(clazz -> "     --initialize-at-build-time=" + clazz)
-                    .collect(Collectors.joining(NEXT_LINE + "\n"));
-                if (!buildTimeInit.isEmpty()) {
-                    wrt.println(buildTimeInit);
+                wrt.print("--initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer$1");
+                wrt.print(NEXT_LINE);
+                wrt.print("--initialize-at-build-time=" + context.getPackageName() + "." +
+                    ApplicationContextConfigurerGenerator.CUSTOMIZER_CLASS_NAME);
+                for (String buildTimeInitClass: context.getBuildTimeInitClasses()) {
+                    wrt.print(NEXT_LINE);
+                    wrt.print("--initialize-at-build-time=" + buildTimeInitClass);
                 }
                 if (context.getConfiguration()
                     .isFeatureEnabled(NativeStaticServiceLoaderSourceGenerator.ID)) {
                     for (int i = 0; i < serviceTypes.size(); i++) {
                         String serviceType = serviceTypes.get(i);
-                        wrt.print("     -H:ServiceLoaderFeatureExcludeServices=" + serviceType);
-                        if (i < serviceTypes.size() - 1) {
-                            wrt.println(NEXT_LINE);
-                        } else {
-                            wrt.println();
-                        }
+                        wrt.print(NEXT_LINE);
+                        wrt.print("-H:ServiceLoaderFeatureExcludeServices=" + serviceType);
                     }
                 }
                 wrt.println();

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/GraalVMOptimizationFeatureSourceGeneratorTest.groovy
@@ -6,7 +6,6 @@ import io.micronaut.aot.core.codegen.AbstractSourceGeneratorSpec
 class GraalVMOptimizationFeatureSourceGeneratorTest extends AbstractSourceGeneratorSpec {
     @Override
     AOTCodeGenerator newGenerator() {
-        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, ['A', 'B', 'C'].join(','))
         new GraalVMOptimizationFeatureSourceGenerator()
     }
 
@@ -19,13 +18,14 @@ class GraalVMOptimizationFeatureSourceGeneratorTest extends AbstractSourceGenera
             doesNotCreateInitializer()
             generatesMetaInfResource("native-image/$packageName/native-image.properties", """
 Args=--initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer\$1 \\
-     --initialize-at-build-time=io.micronaut.test.AOTApplicationContextConfigurer \\
+     --initialize-at-build-time=io.micronaut.test.AOTApplicationContextConfigurer
 """)
         }
     }
 
     def "generates a feature file excluding service loading"() {
         when:
+        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, ['A', 'B', 'C'].join(','))
         props.put("${NativeStaticServiceLoaderSourceGenerator.ID}.enabled".toString(), "true")
         generate()
 
@@ -38,6 +38,26 @@ Args=--initialize-at-build-time=io.micronaut.context.ApplicationContextConfigure
      -H:ServiceLoaderFeatureExcludeServices=A \\
      -H:ServiceLoaderFeatureExcludeServices=B \\
      -H:ServiceLoaderFeatureExcludeServices=C
+""")
+        }
+    }
+
+    def "generates a feature file with build time init service"() {
+        when:
+        props.put("${NativeStaticServiceLoaderSourceGenerator.ID}.enabled".toString(), "true")
+        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, TestService.name)
+        context.registerBuildTimeInit(TestService.name)
+
+        generate()
+
+        then:
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            generatesMetaInfResource("native-image/$packageName/native-image.properties", """
+Args=--initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer\$1 \\
+     --initialize-at-build-time=io.micronaut.test.AOTApplicationContextConfigurer \\
+     --initialize-at-build-time=io.micronaut.aot.std.sourcegen.TestService \\
+     -H:ServiceLoaderFeatureExcludeServices=io.micronaut.aot.std.sourcegen.TestService
 """)
         }
     }


### PR DESCRIPTION
The native-image.properties might omit a "\\" at the end of line when buildTimeInitClasses are specified in the context. This is fixed by this PR. The file is reformatted to always have the correct structure

As an example, before the fix I had these `native-image.properties` file generated by AOT:
```properties
Args=--initialize-at-build-time=io.micronaut.context.ApplicationContextConfigurer$1 \
     --initialize-at-build-time=com.oracle.pic.sample.cp.api.AOTApplicationContextConfigurer \
     --initialize-at-build-time=com.oracle.pic.sample.cp.api.PropertySourceLoaderFactory \
     --initialize-at-build-time=com.oracle.pic.sample.cp.api.BeanDefinitionReferenceFactory \
     --initialize-at-build-time=io.micronaut.core.io.service.SoftServiceLoader$Optimizations \
     --initialize-at-build-time=io.micronaut.core.reflect.ClassUtils$Optimizations \
     --initialize-at-build-time=io.micronaut.core.async.publisher.PublishersOptimizations \
     --initialize-at-build-time=com.oracle.pic.sample.cp.api.BeanIntrospectionReferenceFactory \
     --initialize-at-build-time=com.oracle.pic.sample.cp.api.BeanConfigurationFactory \
     --initialize-at-build-time=com.oracle.pic.sample.cp.api.TypeConverterRegistrarFactory \
     --initialize-at-build-time=com.oracle.pic.sample.cp.api.PropertyExpressionResolverFactory \
     --initialize-at-build-time=com.oracle.pic.sample.cp.api.HttpResponseFactoryFactory \
     --initialize-at-build-time=com.oracle.pic.sample.cp.api.HttpRequestFactoryFactory
     -H:ServiceLoaderFeatureExcludeServices=io.micronaut.context.env.PropertySourceLoader \
     -H:ServiceLoaderFeatureExcludeServices=io.micronaut.inject.BeanConfiguration \
     -H:ServiceLoaderFeatureExcludeServices=io.micronaut.inject.BeanDefinitionReference \
     -H:ServiceLoaderFeatureExcludeServices=io.micronaut.http.HttpRequestFactory \
     -H:ServiceLoaderFeatureExcludeServices=io.micronaut.http.HttpResponseFactory \
     -H:ServiceLoaderFeatureExcludeServices=io.micronaut.core.beans.BeanIntrospectionReference \
     -H:ServiceLoaderFeatureExcludeServices=io.micronaut.core.convert.TypeConverterRegistrar \
     -H:ServiceLoaderFeatureExcludeServices=io.micronaut.context.env.PropertyExpressionResolver
```
when I used the following config:
```properties
cached.environment.enabled=false
precompute.environment.properties.enabled=false
logback.xml.to.java.enabled=false
yaml.to.java.config.enabled=false
properties.to.java.config.enabled=false
serviceloading.native.enabled=true
serviceloading.jit.enabled=true
graalvm.config.enabled=true
possible.environments=dev,prod,oc1
target.environments=prod,oc1
scan.reactive.types.enabled=true
deduce.environment.enabled=false
known.missing.types.enabled=true
sealed.property.source.enabled=false
service.types=io.micronaut.context.env.PropertySourceLoader,io.micronaut.inject.BeanConfiguration,io.micronaut.inject.BeanDefinitionReference,io.micronaut.http.HttpRequestFactory,io.micronaut.http.HttpResponseFactory,io.micronaut.core.beans.BeanIntrospectionReference,io.micronaut.core.convert.TypeConverterRegistrar,io.micronaut.context.env.PropertyExpressionResolver
known.missing.types.list=io.reactivex.Observable,reactor.core.publisher.Flux,kotlinx.coroutines.flow.Flow,io.reactivex.rxjava3.core.Flowable,io.reactivex.rxjava3.core.Observable,io.reactivex.Single,reactor.core.publisher.Mono,io.reactivex.Maybe,io.reactivex.rxjava3.core.Single,io.reactivex.rxjava3.core.Maybe,io.reactivex.Completable,io.reactivex.rxjava3.core.Completable,io.methvin.watchservice.MacOSXListeningWatchService,io.micronaut.core.async.publisher.CompletableFuturePublisher,io.micronaut.core.async.publisher.Publishers.JustPublisher,io.micronaut.core.async.subscriber.Completable
```