### PR TITLE
Improvement for property loader generation

### DIFF
--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -67,6 +67,7 @@ ${toPropertiesSample(JitStaticServiceLoaderSourceGenerator, Environments.POSSIBL
 ${toPropertiesSample(GenericPropertySourceGenerator, "property-source-loader.types")}
 ${toPropertiesSample(GenericPropertySourceGenerator, "property-source-loader.base-order")}
 ${toPropertiesSample(GenericPropertySourceGenerator, "property-source-loader.resource-names")}
+${toPropertiesSample(GenericPropertySourceGenerator, "property-source-loader.service-loader-exclude")}
 ${toPropertiesSample(GenericPropertySourceGenerator, "yaml.to.java.config")}"""],
                 [ConstantPropertySourcesSourceGenerator.DESCRIPTION, "sealed.property.source.enabled = true"],
         ].findAll().collect { desc, c ->

--- a/aot-core/src/main/java/io/micronaut/aot/core/AOTContext.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/AOTContext.java
@@ -114,6 +114,22 @@ public interface AOTContext {
     void registerExcludedResource(@NonNull String path);
 
     /**
+     * Register an excluded service implementation that is based on another generator and not user input.
+     * When static service loader is created, this implementation won't be added and therefore won't be loaded.
+     *
+     * @param className The service implementation classname
+     * @param reason The human-readable reason for exclusion
+     */
+    void registerExcludedServiceImpl(@NonNull String className, @NonNull String reason);
+
+    /**
+     * Get the excluded service implementations.
+     *
+     * @return The implementations with key being the classname and value being the reason for exclusion.
+     */
+    Map<String, String> getExcludedServiceImplementations();
+
+    /**
      * Registers a class as needed at compile time (where compile time
      * is the compile time of generated classes).
      * This will typically be used when source generators need classes
@@ -198,4 +214,5 @@ public interface AOTContext {
      * source generation.
      */
     void finish();
+
 }

--- a/aot-core/src/main/java/io/micronaut/aot/core/codegen/DelegatingSourceGenerationContext.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/codegen/DelegatingSourceGenerationContext.java
@@ -67,6 +67,16 @@ public abstract class DelegatingSourceGenerationContext implements AOTContext {
     }
 
     @Override
+    public void registerExcludedServiceImpl(String className, String reason) {
+        delegate.registerExcludedServiceImpl(className, reason);
+    }
+
+    @Override
+    public Map<String, String> getExcludedServiceImplementations() {
+        return delegate.getExcludedServiceImplementations();
+    }
+
+    @Override
     public void registerStaticInitializer(MethodSpec staticInitializer) {
         delegate.registerStaticInitializer(staticInitializer);
     }

--- a/aot-core/src/main/java/io/micronaut/aot/core/context/DefaultSourceGenerationContext.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/context/DefaultSourceGenerationContext.java
@@ -69,6 +69,7 @@ public final class DefaultSourceGenerationContext implements AOTContext {
     private final String packageName;
     private final ApplicationContextAnalyzer analyzer;
     private final Set<String> excludedResources = new TreeSet<>();
+    private final Map<String, String>  excludedServiceImplementations = new HashMap<>();
     private final Map<String, List<String>> diagnostics = new ConcurrentHashMap<>();
     private final Set<Class<?>> classesRequiredAtCompilation = new HashSet<>();
     private final Configuration configuration;
@@ -117,6 +118,16 @@ public final class DefaultSourceGenerationContext implements AOTContext {
     public void registerExcludedResource(@NonNull String path) {
         LOGGER.debug("Registering excluded resource: {}", path);
         excludedResources.add(path);
+    }
+
+    @Override
+    public void registerExcludedServiceImpl(String className, String reason) {
+        excludedServiceImplementations.put(className, reason);
+    }
+
+    @Override
+    public Map<String, String> getExcludedServiceImplementations() {
+        return Collections.unmodifiableMap(excludedServiceImplementations);
     }
 
     @Override

--- a/aot-core/src/testFixtures/groovy/io/micronaut/aot/core/codegen/AbstractSourceGeneratorSpec.groovy
+++ b/aot-core/src/testFixtures/groovy/io/micronaut/aot/core/codegen/AbstractSourceGeneratorSpec.groovy
@@ -283,6 +283,7 @@ abstract class AbstractSourceGeneratorSpec extends Specification {
                 println("EXPECTED")
                 println("========")
                 println(expectedSource)
+                println("========")
             }
             assert actualSources == expectedSource
         }

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/AbstractStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/AbstractStaticServiceLoaderSourceGenerator.java
@@ -184,6 +184,16 @@ public abstract class AbstractStaticServiceLoaderSourceGenerator extends Abstrac
             if (rejectedClasses.test(className) || !seen.add(className)) {
                 return null;
             }
+            if (context.getExcludedServiceImplementations().containsKey(className)) {
+                if (forceInclude.contains(className)) {
+                    context.addDiagnostics(SERVICE_LOADING_CATEGORY, "Forcing inclusion of %s even despite being excluded for reason: %s"
+                        .formatted(className, context.getExcludedServiceImplementations().get(className)));
+                } else {
+                    context.addDiagnostics(SERVICE_LOADING_CATEGORY, "Excluding service implementation %s for reason: %s"
+                        .formatted(className, context.getExcludedServiceImplementations().get(className)));
+                    return null;
+                }
+            }
             AbstractCodeGenerator substitution = substitutions.get(className);
             if (substitution != null) {
                 var javaFiles = new ArrayList<JavaFile>();

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GenericPropertySourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GenericPropertySourceGenerator.java
@@ -70,6 +70,10 @@ import java.util.stream.Collectors;
         description = "The resource names to generate property sources for. By default, it is '" + Environment.DEFAULT_NAME + "," + Environment.BOOTSTRAP_NAME + "'.",
         sampleValue = Environment.DEFAULT_NAME + "," + Environment.BOOTSTRAP_NAME
     ), @Option(
+        key = "property-source-loader.service-loader-exclude",
+        description = "Whether the property source loaders specified by types should be excluded in service loading",
+        sampleValue = StringUtils.TRUE
+    ), @Option(
         key = "yaml.to.java.config",
         description = "Deprecated option to enable the yaml property source generation. " +
             "Use property-source-loader.types=io.micronaut.context.env.yaml.YamlPropertySourceLoader instead",
@@ -88,8 +92,10 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
         MetadataUtils.findMetadata(GenericPropertySourceGenerator.class).get().options()[1];
     public static final Option RESOURCE_NAMES_OPTION =
         MetadataUtils.findMetadata(GenericPropertySourceGenerator.class).get().options()[2];
-    public static final Option YAML_GENERATION_OPTION =
+    public static final Option SERVICE_LOADER_EXCLUDE_OPTION =
         MetadataUtils.findMetadata(GenericPropertySourceGenerator.class).get().options()[3];
+    public static final Option YAML_GENERATION_OPTION =
+        MetadataUtils.findMetadata(GenericPropertySourceGenerator.class).get().options()[4];
 
     public static final String YAML_PROPERTY_SOURCE_LOADER = YamlPropertySourceLoader.class.getName();
 
@@ -99,6 +105,7 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
     private final List<String> propertySourceLoaderTypes;
     private final int baseOrder;
     private final Collection<ActiveEnvironment> environments;
+    private final boolean serviceLoaderExclude;
 
     /**
      * Create the generic property source generator from resource names.
@@ -132,6 +139,8 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
         this.baseOrder = context.getConfiguration().optionalValue(BASE_ORDER_OPTION.key(),
             v -> v.map(Integer::parseInt).orElse(Ordered.HIGHEST_PRECEDENCE / 2));
         this.environments = environments;
+        this.serviceLoaderExclude = context.getConfiguration().optionalValue(SERVICE_LOADER_EXCLUDE_OPTION.key(),
+            v -> v.map(Boolean::parseBoolean).orElse(true));
     }
 
     @Override
@@ -139,6 +148,14 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
         for (String propertySourceLoaderType : propertySourceLoaderTypes) {
             Optional<PropertySourceLoader> loader = createLoader(propertySourceLoaderType);
             if (loader.isPresent()) {
+                if (serviceLoaderExclude) {
+                    context.registerExcludedServiceImpl(
+                        propertySourceLoaderType,
+                        "Excluded by %s because property sources are generated based on the loader as specified by %s"
+                            .formatted(this.getClass().getSimpleName(), TYPES_OPTION.key())
+                    );
+                }
+
                 for (String resource : resources) {
                     createMapProperty(loader.get(), context, resource, null);
                     for (ActiveEnvironment environment : environments) {

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GenericPropertySourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GenericPropertySourceGenerator.java
@@ -24,6 +24,7 @@ import io.micronaut.context.env.ActiveEnvironment;
 import io.micronaut.context.env.EmptyPropertySource;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.MapPropertySource;
+import io.micronaut.context.env.PropertiesPropertySourceLoader;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.env.PropertySourceLoader;
 import io.micronaut.context.env.yaml.YamlPropertySourceLoader;
@@ -39,10 +40,12 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * A source generator which will generate a static {@link PropertySource}
@@ -56,7 +59,7 @@ import java.util.Optional;
     options = {@Option(
         key = "property-source-loader.types",
         description = "The PropertySourceLoader classnames to use for generating property sources",
-        sampleValue = "io.micronaut.context.env.PropertiesPropertySourceLoader,"
+        sampleValue = "io.micronaut.context.env.PropertiesPropertySourceLoader, io.micronaut.context.env.yaml.YamlPropertySourceLoader"
     ), @Option(
         key = "property-source-loader.base-order",
         description = "The base order to use for the generated property sources. "
@@ -119,6 +122,11 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
                 propertySourceLoaderTypes = new ArrayList<>(propertySourceLoaderTypes);
                 propertySourceLoaderTypes.add(YAML_PROPERTY_SOURCE_LOADER);
             }
+        }
+        if (propertySourceLoaderTypes.isEmpty()) {
+            LOG.info("Option {} has no value. Using default instead: {}", TYPES_OPTION.key(), TYPES_OPTION.sampleValue());
+            propertySourceLoaderTypes = Arrays.stream(TYPES_OPTION.sampleValue().split(","))
+                .map(String::trim).collect(Collectors.toList());
         }
         this.propertySourceLoaderTypes = propertySourceLoaderTypes;
         this.baseOrder = context.getConfiguration().optionalValue(BASE_ORDER_OPTION.key(),

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/GenericPropertySourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/GenericPropertySourceGeneratorTest.groovy
@@ -40,6 +40,9 @@ class GenericPropertySourceGeneratorTest extends AbstractSourceGeneratorSpec {
         generate()
 
         then:
+        var excludedImpls = context.getExcludedServiceImplementations()
+        excludedImpls.keySet() == [MyPropertySourceLoader.class.getName(), PropertiesPropertySourceLoader.class.getName()] as Set
+
         assertThatGeneratedSources {
             doesNotCreateInitializer()
             hasClass("ApplicationMyStaticPropertySource") {

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/NativeStaticServiceLoaderSourceGeneratorTest.groovy
@@ -142,4 +142,49 @@ public class TestServiceWithMoreThanOneImplFactory implements SoftServiceLoader.
             }
         }
     }
+
+
+    def "generates a service loader with excludes"() {
+        props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, TestServiceWithMoreThanOneImpl.name)
+        context.registerExcludedServiceImpl("io.micronaut.aot.std.sourcegen.TestServiceImpl2", "Excluded by another generator")
+
+        when:
+        generate()
+
+        then:
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            hasClass("StaticServicesLoader") {
+                containingSources('staticServices.put("io.micronaut.aot.std.sourcegen.TestServiceWithMoreThanOneImpl", new TestServiceWithMoreThanOneImplFactory());')
+            }
+
+            hasClass("TestServiceWithMoreThanOneImplFactory") {
+                withSources """
+                package io.micronaut.test;
+
+                import io.micronaut.aot.std.sourcegen.TestServiceImpl;
+                import io.micronaut.aot.std.sourcegen.TestServiceWithMoreThanOneImpl;
+                import io.micronaut.core.annotation.Generated;
+                import io.micronaut.core.io.service.SoftServiceLoader;
+                import java.lang.String;
+                import java.util.ArrayList;
+                import java.util.List;
+                import java.util.function.Predicate;
+                import java.util.stream.Stream;
+
+                @Generated
+                public class TestServiceWithMoreThanOneImplFactory implements SoftServiceLoader.StaticServiceLoader<TestServiceWithMoreThanOneImpl> {
+                  public Stream<SoftServiceLoader.StaticDefinition<TestServiceWithMoreThanOneImpl>> findAll(
+                      Predicate<String> predicate) {
+                    List<SoftServiceLoader.StaticDefinition<TestServiceWithMoreThanOneImpl>> list = new ArrayList<>();
+                    if (predicate.test("io.micronaut.aot.std.sourcegen.TestServiceImpl")) {
+                      list.add(SoftServiceLoader.StaticDefinition.of("io.micronaut.aot.std.sourcegen.TestServiceImpl", TestServiceImpl::new));
+                    }
+                    return list.stream();
+                  }
+                }
+                """.stripIndent()
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Add default value for `property-source-loader.types`
- Exclude the property source loaders from static service loading.
  Currently they are included and therefore properties might be retrieved twice. This makes them excluded by default, since user might forget to exclude them with a property.