### PR TITLE
Fix yaml generation compatability

### DIFF
--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/AbstractStaticServiceLoaderSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/AbstractStaticServiceLoaderSourceGenerator.java
@@ -99,7 +99,8 @@ public abstract class AbstractStaticServiceLoaderSourceGenerator extends Abstrac
                 .filter(env -> !"default".equals(env)).toList()
             );
             substitutions = new HashMap<>();
-            if (context.getConfiguration().isFeatureEnabled(GenericPropertySourceGenerator.ID)) {
+            if (context.getConfiguration().isFeatureEnabled(GenericPropertySourceGenerator.ID)
+                    || context.getConfiguration().booleanValue(GenericPropertySourceGenerator.YAML_GENERATION_OPTION.key(), false)) {
                 List<ActiveEnvironment> environments = new ArrayList<>();
                 int i = 0;
                 for (String name: environmentNames) {

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GenericPropertySourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GenericPropertySourceGenerator.java
@@ -74,7 +74,7 @@ import java.util.stream.Collectors;
         description = "Whether the property source loaders specified by types should be excluded in service loading",
         sampleValue = StringUtils.TRUE
     ), @Option(
-        key = "yaml.to.java.config",
+        key = "yaml.to.java.config.enabled",
         description = "Deprecated option to enable the yaml property source generation. " +
             "Use property-source-loader.types=io.micronaut.context.env.yaml.YamlPropertySourceLoader instead",
         sampleValue = "false"


### PR DESCRIPTION
Make yaml generation backward compatible by running GenericPropertySourceGenerator when old property is set.

Related to https://github.com/micronaut-projects/micronaut-maven-plugin/pull/1420.