### PR TITLE
docs: clarify AOT code generator source layout

### DIFF
--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -117,6 +117,10 @@ New capabilities will be included as part of AOT development.
 At the core of AOT optimizations is a _code generator_.
 A code generator needs to implement the `AOTCodeGenerator` interface and be annotated with `@AOTModule`.
 
+The implementation class should be compiled from the regular Java source root of an AOT optimizer module, for example `src/main/java`.
+Register the generator with Java's `ServiceLoader` mechanism by adding its fully qualified class name to `src/main/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator`.
+Build tool integrations load optimizer modules from the AOT optimizer classpath; for example, Gradle users can add the optimizer artifact or project dependency to the `aotPlugins` configuration.
+
 The `AOTModule` annotation is responsible for giving metadata about the code generators, including:
 
 - an `id` is used to identify the code generator, and enable/disable it via configuration


### PR DESCRIPTION
## Summary
- Document that `AOTCodeGenerator` implementations should live under a regular Java source root such as `src/main/java`
- Document the `ServiceLoader` descriptor path for registering AOT code generators
- Point Gradle users to `aotPlugins` for wiring optimizer artifacts or project dependencies

Closes #223

## Verification
- `git diff --check origin/3.0.x...HEAD`
- `./gradlew publishGuide`

## Project Routing
QA selected the Micronaut organization project set `5.0.0-M3` and `5.0.0 Release` for this AOT `3.0.x` docs change because both prerelease and GA Platform 5.0 boards are open. This PR should be linked to both projects.

---
###### ✨ This message was AI-generated using GPT-5