### PR TITLE
Fix logback AOT conversion without logback config

### DIFF
--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGenerator.java
@@ -47,11 +47,7 @@ public class LogbackConfigurationSourceGenerator extends AbstractSingleClassFile
     @Override
     @NonNull
     protected JavaFile generate() {
-        try {
-            Class.forName("ch.qos.logback.core.model.Model");
-        } catch (ClassNotFoundException e) {
-            throw new IllegalStateException("The logback.xml conversion feature requires logback 1.4 on the AOT optimizer classpath.");
-        }
+        checkLogback14Present();
         TypeSpec typeSpec = TypeSpec.classBuilder("StaticLogbackConfiguration")
                 .addModifiers(Modifier.PUBLIC)
                 .addSuperinterface(Configurator.class)
@@ -70,6 +66,14 @@ public class LogbackConfigurationSourceGenerator extends AbstractSingleClassFile
         return javaFile(typeSpec);
     }
 
+    private static void checkLogback14Present() {
+        try {
+            Class.forName("ch.qos.logback.core.model.Model");
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("The logback.xml conversion feature requires logback 1.4 on the AOT optimizer classpath.");
+        }
+    }
+
     /**
      * Returns the name of the logback configuration file.
      * Can be overridden in tests.
@@ -82,8 +86,14 @@ public class LogbackConfigurationSourceGenerator extends AbstractSingleClassFile
 
     @Override
     public void generate(@NonNull AOTContext context) {
+        String logbackFileName = getLogbackFileName();
+        ClassLoader classLoader = context.getAnalyzer().getApplicationContext().getClass().getClassLoader();
+        if (classLoader.getResource(logbackFileName) == null) {
+            context.addDiagnostics(ID, "Skipping logback configuration conversion because " + logbackFileName + " was not found on the application classpath.");
+            return;
+        }
         super.generate(context);
-        context.registerExcludedResource(getLogbackFileName());
+        context.registerExcludedResource(logbackFileName);
         context.registerServiceImplementation(Configurator.class, "StaticLogbackConfiguration");
     }
 

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/LogbackConfigurationSourceGeneratorTest.groovy
@@ -121,6 +121,20 @@ public class StaticLogbackConfiguration implements Configurator {
         }
     }
 
+    def "does not generate configuration when logback file is not present"() {
+        configFileName = "logback-missing.xml"
+
+        when:
+        generate()
+
+        then:
+        excludesResources()
+        assertThatGeneratedSources {
+            doesNotCreateInitializer()
+            doesNotGenerateClasses()
+        }
+    }
+
     def "converts configuration using file logger"() {
         configFileName = "logback-test2.xml"
 


### PR DESCRIPTION
## Summary
- Skip the logback XML conversion optimizer when the configured logback resource is absent from the analyzed application classpath.
- Preserve the existing Logback 1.4 validation and conversion path when a logback resource is present.
- Add regression coverage for the missing-logback-resource path.

## Rationale
A generated app using Log4j2 does not include `logback.xml`, but the default AOT optimizer path could still try to run logback XML conversion and fail before `prepareJitOptimizations` completed. The fix treats an absent logback resource as a no-op for this optimizer instead of requiring logback conversion dependencies for non-logback applications.

## QA / Security
- QA approved the branch as an internal patch bug fix for `3.0.x`.
- Security review approved commit `9ed5abb766838711862a8e34f27b1a028d1f167b`; no exploit path, insecure default, secret, permission, or supply-chain regression was found.

## Project Routing
QA selected the following Micronaut organization projects for this PR: `5.0.0-M3` and `5.0.0 Release`.

Ambiguity note: the imported issue currently has project item `4.9.4 Release`, but that board is closed and does not match the live `3.0.x` / `3.0.0-SNAPSHOT` branch evidence. No open public AOT-specific `3.0.0` organization project was found, so QA selected the open Micronaut 5.0 release boards as the best-fit forward set.

Live project linkage note: Code Review attempted to add this PR to `5.0.0-M3` and `5.0.0 Release` with `gh project item-add`, but the available `GITHUB_TOKEN` is missing the required `project` scope. The selected project set is recorded here for maintainers, but the live PR project items could not be applied from this run.

## Verification
- `./gradlew :micronaut-aot-std-optimizers:test --tests 'io.micronaut.aot.std.sourcegen.LogbackConfigurationSourceGeneratorTest'`
- `./gradlew :micronaut-aot-std-optimizers:check`
- `git diff --check origin/3.0.x...HEAD`

Fixes #321

---
###### ✨ This message was AI-generated using gpt-5.5