### PR TITLE
Configure SLF4J provider for AOT CLI

### DIFF
--- a/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
+++ b/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
@@ -44,6 +44,9 @@ import java.util.stream.Collectors;
         versionProvider = VersionProvider.class,
         description = "Generates classes for Micronaut AOT (build time optimizations)")
 public class Main implements Runnable, ConfigKeys {
+    static final String SLF4J_INTERNAL_VERBOSITY = "slf4j.internal.verbosity";
+    static final String SLF4J_PROVIDER = "slf4j.provider";
+    static final String LOGBACK_SERVICE_PROVIDER = "ch.qos.logback.classic.spi.LogbackServiceProvider";
 
     @Option(names = {"--classpath", "-cp"}, description = "The Micronaut application classpath", required = true)
     private String classpathString;
@@ -62,6 +65,7 @@ public class Main implements Runnable, ConfigKeys {
 
     @Override
     public void run() {
+        configureSlf4j();
         List<URL> classpath = toURLs(classpathString);
         var props = new Properties();
         if (config.exists()) {
@@ -113,6 +117,17 @@ public class Main implements Runnable, ConfigKeys {
             throw new RuntimeException(e);
         } finally {
             Thread.currentThread().setContextClassLoader(ctxClassLoader);
+        }
+    }
+
+    static void configureSlf4j() {
+        setSystemPropertyIfMissing(SLF4J_INTERNAL_VERBOSITY, "WARN");
+        setSystemPropertyIfMissing(SLF4J_PROVIDER, LOGBACK_SERVICE_PROVIDER);
+    }
+
+    private static void setSystemPropertyIfMissing(String key, String value) {
+        if (System.getProperty(key) == null) {
+            System.setProperty(key, value);
         }
     }
 

--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -27,6 +27,44 @@ class CliTest extends Specification {
     @TempDir
     Path testDirectory
 
+    def "configures slf4j to use logback without provider lookup"() {
+        given:
+        def existingVerbosity = System.getProperty(Main.SLF4J_INTERNAL_VERBOSITY)
+        def existingProvider = System.getProperty(Main.SLF4J_PROVIDER)
+        System.clearProperty(Main.SLF4J_INTERNAL_VERBOSITY)
+        System.clearProperty(Main.SLF4J_PROVIDER)
+
+        when:
+        Main.configureSlf4j()
+
+        then:
+        System.getProperty(Main.SLF4J_INTERNAL_VERBOSITY) == 'WARN'
+        System.getProperty(Main.SLF4J_PROVIDER) == Main.LOGBACK_SERVICE_PROVIDER
+
+        cleanup:
+        restoreSystemProperty(Main.SLF4J_INTERNAL_VERBOSITY, existingVerbosity)
+        restoreSystemProperty(Main.SLF4J_PROVIDER, existingProvider)
+    }
+
+    def "keeps user provided slf4j system properties"() {
+        given:
+        def existingVerbosity = System.getProperty(Main.SLF4J_INTERNAL_VERBOSITY)
+        def existingProvider = System.getProperty(Main.SLF4J_PROVIDER)
+        System.setProperty(Main.SLF4J_INTERNAL_VERBOSITY, 'ERROR')
+        System.setProperty(Main.SLF4J_PROVIDER, 'example.CustomServiceProvider')
+
+        when:
+        Main.configureSlf4j()
+
+        then:
+        System.getProperty(Main.SLF4J_INTERNAL_VERBOSITY) == 'ERROR'
+        System.getProperty(Main.SLF4J_PROVIDER) == 'example.CustomServiceProvider'
+
+        cleanup:
+        restoreSystemProperty(Main.SLF4J_INTERNAL_VERBOSITY, existingVerbosity)
+        restoreSystemProperty(Main.SLF4J_PROVIDER, existingProvider)
+    }
+
     @Unroll
     def "can export a dummy configuration file"() {
         def configFile = testDirectory.resolve("${runtime}.properties")
@@ -97,6 +135,14 @@ ${Environments.TARGET_ENVIRONMENTS_NAMES} = ${Environments.TARGET_ENVIRONMENTS_S
         return MetadataUtils.toPropertiesSample(
                 MetadataUtils.findOption(clazz, name)
         )
+    }
+
+    private static void restoreSystemProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key)
+        } else {
+            System.setProperty(key, value)
+        }
     }
 
     @CompileStatic


### PR DESCRIPTION
## Summary
- Configure the AOT CLI to default SLF4J internal verbosity to `WARN`.
- Configure the AOT CLI to use Logback's SLF4J provider directly.
- Preserve caller-provided SLF4J system properties.

## Project Targeting
Micronaut AOT targets the `3.0.x` / `3.0.0` line, while the open public Micronaut organization release boards are Platform boards. QA selected both `5.0.0-M3` and `5.0.0 Release` as the best-fit Platform release boards for this PR.

## Verification
- `git diff --check origin/3.0.x...HEAD`
- `./gradlew :micronaut-aot-cli:test --tests io.micronaut.aot.cli.CliTest`
- `./gradlew :micronaut-aot-cli:test --tests io.micronaut.aot.cli.CliTest --rerun-tasks`

Closes #394

---
###### ✨ This message was AI-generated using gpt-5
