### PR TITLE
Fix yaml generation compatability

### DIFF
--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -177,7 +177,7 @@ ${toPropertiesSample(GenericPropertySourceGenerator, "property-source-loader.typ
 ${toPropertiesSample(GenericPropertySourceGenerator, "property-source-loader.base-order")}
 ${toPropertiesSample(GenericPropertySourceGenerator, "property-source-loader.resource-names")}
 ${toPropertiesSample(GenericPropertySourceGenerator, "property-source-loader.service-loader-exclude")}
-${toPropertiesSample(GenericPropertySourceGenerator, "yaml.to.java.config")}"""],
+${toPropertiesSample(GenericPropertySourceGenerator, "yaml.to.java.config.enabled")}"""],
                 [PublishersSourceGenerator.DESCRIPTION, 'scan.reactive.types.enabled = true'],
                 [ConstantPropertySourcesSourceGenerator.DESCRIPTION, "sealed.property.source.enabled = true"],
         ].findAll().collect { desc, c ->

--- a/aot-core/src/main/java/io/micronaut/aot/core/config/SourceGeneratorLoader.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/config/SourceGeneratorLoader.java
@@ -41,6 +41,8 @@ import static java.util.stream.StreamSupport.stream;
  */
 public class SourceGeneratorLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(SourceGeneratorLoader.class);
+    private static final String PROPERTY_SOURCE_LOADER_GENERATOR_ID = "property-source-loader.generate";
+    private static final String DEPRECATED_YAML_TO_JAVA_CONFIG_ENABLED = "yaml.to.java.config.enabled";
 
     private static final Comparator<AOTModule> EXECUTION_ORDER = (first, second) -> {
         if (Arrays.asList(first.dependencies()).contains(second.id())) {
@@ -76,7 +78,7 @@ public class SourceGeneratorLoader {
                         LOGGER.debug("Skipping source generator {} as it is not enabled on runtime {}", sg.generator.getClass().getName(), runtime);
                         return new SourceGeneratorSelection(sg.generator, sg.module, false, SourceGeneratorSelection.NOT_ENABLED_ON_RUNTIME);
                     }
-                    boolean isEnabledByConfiguration = configuration.isFeatureEnabled(sg.module.id());
+                    boolean isEnabledByConfiguration = isEnabledByConfiguration(configuration, sg.module);
                     if (!isEnabledByConfiguration) {
                         LOGGER.debug("Skipping source generator {} as it is not enabled by configuration", sg.generator.getClass().getName());
                         return new SourceGeneratorSelection(sg.generator, sg.module, false, SourceGeneratorSelection.DISABLED_BY_CONFIGURATION);
@@ -119,6 +121,12 @@ public class SourceGeneratorLoader {
             return 1;
         }
         return first.getGenerator().getClass().getName().compareTo(second.getGenerator().getClass().getName());
+    }
+
+    private static boolean isEnabledByConfiguration(Configuration configuration, AOTModule module) {
+        return configuration.isFeatureEnabled(module.id()) ||
+            PROPERTY_SOURCE_LOADER_GENERATOR_ID.equals(module.id()) &&
+                configuration.booleanValue(DEPRECATED_YAML_TO_JAVA_CONFIG_ENABLED, false);
     }
 
 }

--- a/aot-core/src/main/java/io/micronaut/aot/core/config/SourceGeneratorLoader.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/config/SourceGeneratorLoader.java
@@ -43,6 +43,7 @@ public class SourceGeneratorLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(SourceGeneratorLoader.class);
     private static final String PROPERTY_SOURCE_LOADER_GENERATOR_ID = "property-source-loader.generate";
     private static final String DEPRECATED_YAML_TO_JAVA_CONFIG_ENABLED = "yaml.to.java.config.enabled";
+    private static final String DEPRECATED_YAML_TO_JAVA_CONFIG = "yaml.to.java.config";
 
     private static final Comparator<AOTModule> EXECUTION_ORDER = (first, second) -> {
         if (Arrays.asList(first.dependencies()).contains(second.id())) {
@@ -126,7 +127,8 @@ public class SourceGeneratorLoader {
     private static boolean isEnabledByConfiguration(Configuration configuration, AOTModule module) {
         return configuration.isFeatureEnabled(module.id()) ||
             PROPERTY_SOURCE_LOADER_GENERATOR_ID.equals(module.id()) &&
-                configuration.booleanValue(DEPRECATED_YAML_TO_JAVA_CONFIG_ENABLED, false);
+                (configuration.booleanValue(DEPRECATED_YAML_TO_JAVA_CONFIG_ENABLED, false) ||
+                    configuration.booleanValue(DEPRECATED_YAML_TO_JAVA_CONFIG, false));
     }
 
 }

--- a/aot-core/src/test/groovy/io/micronaut/aot/core/config/SourceGeneratorLoaderTest.groovy
+++ b/aot-core/src/test/groovy/io/micronaut/aot/core/config/SourceGeneratorLoaderTest.groovy
@@ -24,6 +24,7 @@ import io.micronaut.aot.core.context.ApplicationContextAnalyzer
 import io.micronaut.aot.core.context.DefaultSourceGenerationContext
 import spock.lang.Specification
 import spock.lang.TempDir
+import spock.lang.Unroll
 
 import java.nio.file.Path
 
@@ -45,10 +46,11 @@ class SourceGeneratorLoaderTest extends Specification {
         sorted*.generator*.class == [FirstGenerator, SecondGenerator, MissingMetadataGenerator]
     }
 
-    def "deprecated yaml generation flag enables property source loader generator"() {
+    @Unroll
+    def "deprecated yaml generation flag #property enables property source loader generator"() {
         given:
         def props = new Properties()
-        props.put("yaml.to.java.config.enabled", "true")
+        props.put(property, "true")
         def config = new DefaultConfiguration(props)
         def context = new DefaultSourceGenerationContext(
                 "io.micronaut.test",
@@ -61,6 +63,9 @@ class SourceGeneratorLoaderTest extends Specification {
         SourceGeneratorLoader.load(Runtime.JIT, context).any {
             it instanceof DeprecatedYamlPropertySourceGenerator
         }
+
+        where:
+        property << ["yaml.to.java.config", "yaml.to.java.config.enabled"]
     }
 
     def "property source loader generator remains disabled without feature flags"() {

--- a/aot-core/src/test/groovy/io/micronaut/aot/core/config/SourceGeneratorLoaderTest.groovy
+++ b/aot-core/src/test/groovy/io/micronaut/aot/core/config/SourceGeneratorLoaderTest.groovy
@@ -1,11 +1,36 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.aot.core.config
 
 import io.micronaut.aot.core.AOTCodeGenerator
 import io.micronaut.aot.core.AOTContext
 import io.micronaut.aot.core.AOTModule
+import io.micronaut.aot.core.Option
+import io.micronaut.aot.core.Runtime
+import io.micronaut.aot.core.context.ApplicationContextAnalyzer
+import io.micronaut.aot.core.context.DefaultSourceGenerationContext
 import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
 
 class SourceGeneratorLoaderTest extends Specification {
+
+    @TempDir
+    Path testDirectory
 
     def "sorts missing metadata selections after metadata-backed selections"() {
         given:
@@ -18,6 +43,40 @@ class SourceGeneratorLoaderTest extends Specification {
 
         then:
         sorted*.generator*.class == [FirstGenerator, SecondGenerator, MissingMetadataGenerator]
+    }
+
+    def "deprecated yaml generation flag enables property source loader generator"() {
+        given:
+        def props = new Properties()
+        props.put("yaml.to.java.config.enabled", "true")
+        def config = new DefaultConfiguration(props)
+        def context = new DefaultSourceGenerationContext(
+                "io.micronaut.test",
+                ApplicationContextAnalyzer.create { },
+                config,
+                testDirectory
+        )
+
+        expect:
+        SourceGeneratorLoader.load(Runtime.JIT, context).any {
+            it instanceof DeprecatedYamlPropertySourceGenerator
+        }
+    }
+
+    def "property source loader generator remains disabled without feature flags"() {
+        given:
+        def config = new DefaultConfiguration(new Properties())
+        def context = new DefaultSourceGenerationContext(
+                "io.micronaut.test",
+                ApplicationContextAnalyzer.create { },
+                config,
+                testDirectory
+        )
+
+        expect:
+        !SourceGeneratorLoader.load(Runtime.JIT, context).any {
+            it instanceof DeprecatedYamlPropertySourceGenerator
+        }
     }
 
     private static SourceGeneratorSelection selection(AOTCodeGenerator generator, boolean enabled) {
@@ -40,6 +99,21 @@ class SourceGeneratorLoaderTest extends Specification {
     }
 
     private static class MissingMetadataGenerator implements AOTCodeGenerator {
+        @Override
+        void generate(AOTContext context) {
+        }
+    }
+
+    @AOTModule(
+            id = "property-source-loader.generate",
+            options = @Option(
+                    key = "yaml.to.java.config.enabled",
+                    description = "Deprecated option to enable the yaml property source generation.",
+                    sampleValue = "false"
+            )
+    )
+    static class DeprecatedYamlPropertySourceGenerator implements AOTCodeGenerator {
+
         @Override
         void generate(AOTContext context) {
         }

--- a/aot-core/src/test/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator
+++ b/aot-core/src/test/resources/META-INF/services/io.micronaut.aot.core.AOTCodeGenerator
@@ -1,0 +1,1 @@
+io.micronaut.aot.core.config.SourceGeneratorLoaderTest$DeprecatedYamlPropertySourceGenerator

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GenericPropertySourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GenericPropertySourceGenerator.java
@@ -74,7 +74,7 @@ import java.util.stream.Collectors;
         description = "Whether the property source loaders specified by types should be excluded in service loading",
         sampleValue = StringUtils.TRUE
     ), @Option(
-        key = "yaml.to.java.config",
+        key = "yaml.to.java.config.enabled",
         description = "Deprecated option to enable the yaml property source generation. " +
             "Use property-source-loader.types=io.micronaut.context.env.yaml.YamlPropertySourceLoader instead",
         sampleValue = "false"
@@ -106,6 +106,7 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
     private final int baseOrder;
     private final Collection<ActiveEnvironment> environments;
     private final boolean serviceLoaderExclude;
+    private final boolean configured;
 
     public GenericPropertySourceGenerator() {
         this.resources = List.of(Environment.DEFAULT_NAME, Environment.BOOTSTRAP_NAME);
@@ -113,6 +114,7 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
         this.baseOrder = Ordered.HIGHEST_PRECEDENCE / 2;
         this.environments = List.of();
         this.serviceLoaderExclude = true;
+        this.configured = false;
     }
 
     /**
@@ -149,10 +151,15 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
         this.environments = environments;
         this.serviceLoaderExclude = context.getConfiguration().optionalValue(SERVICE_LOADER_EXCLUDE_OPTION.key(),
             v -> v.map(Boolean::parseBoolean).orElse(true));
+        this.configured = true;
     }
 
     @Override
     public void generate(@NonNull AOTContext context) {
+        if (!configured) {
+            new GenericPropertySourceGenerator(context, activeEnvironments(context)).generate(context);
+            return;
+        }
         for (String propertySourceLoaderType : propertySourceLoaderTypes) {
             Optional<PropertySourceLoader> loader = createLoader(propertySourceLoaderType);
             if (loader.isPresent()) {
@@ -172,6 +179,19 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
                 }
             }
         }
+    }
+
+    private static Collection<ActiveEnvironment> activeEnvironments(AOTContext context) {
+        List<ActiveEnvironment> environments = new ArrayList<>();
+        int priority = 0;
+        List<String> environmentNames = context.getAnalyzer().getEnvironmentNames().stream()
+            .filter(name -> !Environment.DEFAULT_NAME.equals(name))
+            .sorted()
+            .collect(Collectors.toList());
+        for (String name : environmentNames) {
+            environments.add(ActiveEnvironment.of(name, priority++));
+        }
+        return environments;
     }
 
     private Optional<PropertySourceLoader> createLoader(String className) {

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GenericPropertySourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/GenericPropertySourceGenerator.java
@@ -17,6 +17,7 @@ package io.micronaut.aot.std.sourcegen;
 
 import io.micronaut.aot.core.AOTContext;
 import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.Configuration;
 import io.micronaut.aot.core.Option;
 import io.micronaut.aot.core.codegen.AbstractCodeGenerator;
 import io.micronaut.aot.core.config.MetadataUtils;
@@ -85,6 +86,7 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
 
     public static final String ID = "property-source-loader.generate";
     public static final String DESCRIPTION = "Converts configuration files supplied by property source loaders to Java configuration";
+    public static final String DEPRECATED_YAML_TO_JAVA_CONFIG = "yaml.to.java.config";
 
     public static final Option TYPES_OPTION =
         MetadataUtils.findMetadata(GenericPropertySourceGenerator.class).get().options()[0];
@@ -132,9 +134,10 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
         this.resources = resources;
         // This option is deprecated
         List<String> propertySourceLoaderTypes = context.getConfiguration().stringList(TYPES_OPTION.key());
-        if (context.getConfiguration().booleanValue(YAML_GENERATION_OPTION.key(), false)) {
+        Optional<String> deprecatedYamlGenerationOption = deprecatedYamlGenerationOption(context.getConfiguration());
+        if (deprecatedYamlGenerationOption.isPresent()) {
             LOG.warn("Option {} is deprecated. Automatically using {}={} instead.",
-                YAML_GENERATION_OPTION, TYPES_OPTION.key(), YAML_PROPERTY_SOURCE_LOADER);
+                deprecatedYamlGenerationOption.get(), TYPES_OPTION.key(), YAML_PROPERTY_SOURCE_LOADER);
             if (!propertySourceLoaderTypes.contains(YAML_PROPERTY_SOURCE_LOADER)) {
                 propertySourceLoaderTypes = new ArrayList<>(propertySourceLoaderTypes);
                 propertySourceLoaderTypes.add(YAML_PROPERTY_SOURCE_LOADER);
@@ -152,6 +155,16 @@ public class GenericPropertySourceGenerator extends AbstractCodeGenerator {
         this.serviceLoaderExclude = context.getConfiguration().optionalValue(SERVICE_LOADER_EXCLUDE_OPTION.key(),
             v -> v.map(Boolean::parseBoolean).orElse(true));
         this.configured = true;
+    }
+
+    private static Optional<String> deprecatedYamlGenerationOption(Configuration configuration) {
+        if (configuration.booleanValue(YAML_GENERATION_OPTION.key(), false)) {
+            return Optional.of(YAML_GENERATION_OPTION.key());
+        }
+        if (configuration.booleanValue(DEPRECATED_YAML_TO_JAVA_CONFIG, false)) {
+            return Optional.of(DEPRECATED_YAML_TO_JAVA_CONFIG);
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/YamlPropertySourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/YamlPropertySourceGeneratorTest.groovy
@@ -24,7 +24,7 @@ class YamlPropertySourceGeneratorTest extends AbstractSourceGeneratorSpec {
     @Override
     AOTCodeGenerator newGenerator() {
         // Setting resource to "test" and environment to "config" will load the "test-config"
-        props.put(GenericPropertySourceGenerator.YAML_GENERATION_OPTION.key(), "true")
+        props.put(GenericPropertySourceGenerator.DEPRECATED_YAML_TO_JAVA_CONFIG, "true")
         props.put(GenericPropertySourceGenerator.RESOURCE_NAMES_OPTION.key(), "test")
         new GenericPropertySourceGenerator()
     }

--- a/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/YamlPropertySourceGeneratorTest.groovy
+++ b/aot-std-optimizers/src/test/groovy/io/micronaut/aot/std/sourcegen/YamlPropertySourceGeneratorTest.groovy
@@ -17,7 +17,7 @@ package io.micronaut.aot.std.sourcegen
 
 import io.micronaut.aot.core.AOTCodeGenerator
 import io.micronaut.aot.core.codegen.AbstractSourceGeneratorSpec
-import io.micronaut.context.env.ActiveEnvironment
+import io.micronaut.context.ApplicationContextBuilder
 
 class YamlPropertySourceGeneratorTest extends AbstractSourceGeneratorSpec {
 
@@ -26,7 +26,12 @@ class YamlPropertySourceGeneratorTest extends AbstractSourceGeneratorSpec {
         // Setting resource to "test" and environment to "config" will load the "test-config"
         props.put(GenericPropertySourceGenerator.YAML_GENERATION_OPTION.key(), "true")
         props.put(GenericPropertySourceGenerator.RESOURCE_NAMES_OPTION.key(), "test")
-        new GenericPropertySourceGenerator(context, [ActiveEnvironment.of("config", 0)])
+        new GenericPropertySourceGenerator()
+    }
+
+    @Override
+    protected void customizeContext(ApplicationContextBuilder builder) {
+        builder.environments("config")
     }
 
     def "generates a class from a YAML configuration file"() {


### PR DESCRIPTION
Recreates #395 against the default branch (`3.0.x`).

The deprecated `yaml.to.java.config.enabled` AOT flag now enables the property source loader generator, preserving compatibility for consumers that still set the old YAML generation property. The service-loaded generator also initializes from the active AOT context before generating, so the deprecated flag follows the same configuration path as `property-source-loader.generate.enabled`.

Verification:
- `./gradlew :micronaut-aot-core:test --tests 'io.micronaut.aot.core.config.SourceGeneratorLoaderTest' :micronaut-aot-std-optimizers:test --tests 'io.micronaut.aot.std.sourcegen.YamlPropertySourceGeneratorTest'`
- `./gradlew :micronaut-aot-cli:test --tests 'io.micronaut.aot.cli.CliTest'`

Related to micronaut-projects/micronaut-maven-plugin#1420.

---
###### ✨ This message was AI-generated using gpt-5
