### PR TITLE
Fix AOT optimizer guide example

### DIFF
--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -138,7 +138,7 @@ For example, a simple code generator which generates a resource file may be decl
 @AOTModule(
     id = MyResourceGenerator.ID,
     options = {
-        @Option(name = "greeter.message", sampleValue = "Hello, world!", description = "The message to write")
+        @Option(key = "greeter.message", sampleValue = "Hello, world!", description = "The message to write")
     }
 )
 public class MyResourceGenerator implements AOTCodeGenerator {
@@ -146,11 +146,13 @@ public class MyResourceGenerator implements AOTCodeGenerator {
 
     @Override
     public void generate(AOTContext context) {
-        context.registerResource("/hello.txt", file -> {
+        context.registerGeneratedResource("/hello.txt", file -> {
             try (PrintWriter writer = new PrintWriter(file)) {
                 String message = context.getConfiguration()
                     .mandatoryValue("greeter.message");
-                writer.println(context.getOption("greeter.message"));
+                writer.println(message);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
         });
     }


### PR DESCRIPTION
## Summary

- updates the AOT code generator example to use the current `@Option(key = ...)` annotation member
- replaces removed `AOTContext` calls with `registerGeneratedResource` and `getConfiguration().mandatoryValue(...)`
- adds exception handling required by the resource writer example

## Validation

- `./gradlew publishGuide`
- compiled a disposable version of the corrected example against `micronaut-aot-core` classes and compile classpath
- `./gradlew publishGuide docs`
- verified rendered guide output contains the corrected API calls
- checked guide links for the Gradle plugin, Maven plugin, repository, and releases pages returned HTTP 200

Paperclip: DEV-299

---
###### ✨ This message was AI-generated using gpt-5.5