### PR TITLE
Add AOT diagnostics report

### DIFF
--- a/aot-api/src/main/java/io/micronaut/aot/ConfigKeys.java
+++ b/aot-api/src/main/java/io/micronaut/aot/ConfigKeys.java
@@ -25,4 +25,9 @@ public interface ConfigKeys {
     String GENERATED_PACKAGE = "package";
     String OUTPUT_DIRECTORY = "output.directory";
     String RUNTIME = "runtime";
+    String REPORT_ENABLED = "micronaut.aot.report.enabled";
+    String REPORT_OUTPUT = "micronaut.aot.report.output";
+    String REPORT_FORMAT = "micronaut.aot.report.format";
+    String REPORT_FORMAT_JSON = "json";
+    String REPORT_FILE_NAME = "micronaut-aot-report.json";
 }

--- a/aot-api/src/main/java/io/micronaut/aot/ConfigKeys.java
+++ b/aot-api/src/main/java/io/micronaut/aot/ConfigKeys.java
@@ -29,5 +29,8 @@ public interface ConfigKeys {
     String REPORT_OUTPUT = "micronaut.aot.report.output";
     String REPORT_FORMAT = "micronaut.aot.report.format";
     String REPORT_FORMAT_JSON = "json";
+    String REPORT_FORMAT_HTML = "html";
+    String REPORT_JSON_FILE_NAME = "micronaut-aot-report.json";
+    String REPORT_HTML_FILE_NAME = "micronaut-aot-report.html";
     String REPORT_FILE_NAME = "micronaut-aot-report.json";
 }

--- a/aot-api/src/main/java/io/micronaut/aot/MicronautAotOptimizer.java
+++ b/aot-api/src/main/java/io/micronaut/aot/MicronautAotOptimizer.java
@@ -26,8 +26,10 @@ import io.micronaut.aot.core.codegen.ApplicationContextConfigurerGenerator;
 import io.micronaut.aot.core.config.DefaultConfiguration;
 import io.micronaut.aot.core.config.MetadataUtils;
 import io.micronaut.aot.core.config.SourceGeneratorLoader;
+import io.micronaut.aot.core.config.SourceGeneratorSelection;
 import io.micronaut.aot.core.context.ApplicationContextAnalyzer;
 import io.micronaut.aot.core.context.DefaultSourceGenerationContext;
+import io.micronaut.aot.core.report.AotDiagnosticReportWriter;
 import io.micronaut.aot.internal.StreamHelper;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.version.SemanticVersion;
@@ -314,6 +316,7 @@ public final class MicronautAotOptimizer implements ConfigKeys {
         }
 
         public Runner execute() {
+            boolean reportEnabled = isReportEnabled();
             var optimizer = new MicronautAotOptimizer(
                 classpath,
                 outputSourcesDirectory,
@@ -330,15 +333,61 @@ public final class MicronautAotOptimizer implements ConfigKeys {
             Set<String> environmentNames = analyzer.getEnvironmentNames();
             LOGGER.info("Analysis will be performed with active environments: {}", environmentNames);
             var context = new DefaultSourceGenerationContext(generatedPackage, analyzer, config, outputClassesDirectory.toPath());
-            List<AOTCodeGenerator> sourceGenerators = SourceGeneratorLoader.load(config.getRuntime(), context);
+            List<SourceGeneratorSelection> sourceGeneratorSelections = SourceGeneratorLoader.inspect(config.getRuntime(), config);
+            List<AOTCodeGenerator> sourceGenerators = sourceGeneratorSelections.stream()
+                .filter(SourceGeneratorSelection::isEnabled)
+                .map(SourceGeneratorSelection::getGenerator)
+                .collect(Collectors.toList());
             ApplicationContextConfigurerGenerator generator = new ApplicationContextConfigurerGenerator(
                 sourceGenerators
             );
             generator.generate(context);
             optimizer.compileGeneratedSources(context.getExtraClasspath(), context.getGeneratedJavaFiles());
             optimizer.writeLogs(context);
+            if (reportEnabled) {
+                optimizer.writeReport(context, sourceGeneratorSelections, environmentNames, reportDirectory());
+            }
             return this;
         }
+
+        private boolean isReportEnabled() {
+            if (!config.booleanValue(REPORT_ENABLED, false)) {
+                return false;
+            }
+            String format = config.optionalString(REPORT_FORMAT, REPORT_FORMAT_JSON);
+            if (!REPORT_FORMAT_JSON.equalsIgnoreCase(format)) {
+                throw new IllegalArgumentException("Unsupported AOT report format '" + format + "'. Supported formats: " + REPORT_FORMAT_JSON);
+            }
+            return true;
+        }
+
+        private File reportDirectory() {
+            String configuredReportDirectory = config.optionalString(REPORT_OUTPUT, null);
+            if (configuredReportDirectory != null && !configuredReportDirectory.isEmpty()) {
+                return new File(configuredReportDirectory);
+            }
+            File outputDirectory = outputSourcesDirectory.getParentFile();
+            if (outputDirectory == null) {
+                outputDirectory = new File(".");
+            }
+            return new File(outputDirectory, "reports");
+        }
+    }
+
+    private void writeReport(DefaultSourceGenerationContext context,
+                             List<SourceGeneratorSelection> sourceGeneratorSelections,
+                             Set<String> environmentNames,
+                             File reportDirectory) {
+        Path reportPath = AotDiagnosticReportWriter.write(
+            reportDirectory.toPath(),
+            context.getRuntime(),
+            context.getPackageName(),
+            environmentNames,
+            sourceGeneratorSelections,
+            context,
+            VersionUtils.getMicronautVersion()
+        );
+        LOGGER.info("Micronaut AOT diagnostics report written to {}", reportPath.toAbsolutePath());
     }
 
 }

--- a/aot-api/src/main/java/io/micronaut/aot/MicronautAotOptimizer.java
+++ b/aot-api/src/main/java/io/micronaut/aot/MicronautAotOptimizer.java
@@ -59,6 +59,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
@@ -279,6 +280,44 @@ public final class MicronautAotOptimizer implements ConfigKeys {
         }
     }
 
+    private void writeReports(DefaultSourceGenerationContext context,
+                              List<SourceGeneratorSelection> sourceGeneratorSelections,
+                              Set<String> environmentNames,
+                              File reportDirectory,
+                              Set<String> reportFormats) {
+        for (String reportFormat : reportFormats) {
+            Path reportPath = writeReport(context, sourceGeneratorSelections, environmentNames, reportDirectory, reportFormat);
+            LOGGER.info("Micronaut AOT diagnostics report written to {}", reportPath.toAbsolutePath());
+        }
+    }
+
+    private Path writeReport(DefaultSourceGenerationContext context,
+                             List<SourceGeneratorSelection> sourceGeneratorSelections,
+                             Set<String> environmentNames,
+                             File reportDirectory,
+                             String reportFormat) {
+        if (REPORT_FORMAT_HTML.equals(reportFormat)) {
+            return AotDiagnosticReportWriter.writeHtml(
+                reportDirectory.toPath(),
+                context.getRuntime(),
+                context.getPackageName(),
+                environmentNames,
+                sourceGeneratorSelections,
+                context,
+                VersionUtils.getMicronautVersion()
+            );
+        }
+        return AotDiagnosticReportWriter.write(
+            reportDirectory.toPath(),
+            context.getRuntime(),
+            context.getPackageName(),
+            environmentNames,
+            sourceGeneratorSelections,
+            context,
+            VersionUtils.getMicronautVersion()
+        );
+    }
+
     /**
      * The main AOT optimizer runner.
      */
@@ -316,7 +355,7 @@ public final class MicronautAotOptimizer implements ConfigKeys {
         }
 
         public Runner execute() {
-            boolean reportEnabled = isReportEnabled();
+            Set<String> reportFormats = reportFormats();
             var optimizer = new MicronautAotOptimizer(
                 classpath,
                 outputSourcesDirectory,
@@ -337,28 +376,36 @@ public final class MicronautAotOptimizer implements ConfigKeys {
             List<AOTCodeGenerator> sourceGenerators = sourceGeneratorSelections.stream()
                 .filter(SourceGeneratorSelection::isEnabled)
                 .map(SourceGeneratorSelection::getGenerator)
-                .collect(Collectors.toList());
+                .toList();
             ApplicationContextConfigurerGenerator generator = new ApplicationContextConfigurerGenerator(
                 sourceGenerators
             );
             generator.generate(context);
             optimizer.compileGeneratedSources(context.getExtraClasspath(), context.getGeneratedJavaFiles());
             optimizer.writeLogs(context);
-            if (reportEnabled) {
-                optimizer.writeReport(context, sourceGeneratorSelections, environmentNames, reportDirectory());
+            if (!reportFormats.isEmpty()) {
+                optimizer.writeReports(context, sourceGeneratorSelections, environmentNames, reportDirectory(), reportFormats);
             }
             return this;
         }
 
-        private boolean isReportEnabled() {
+        private Set<String> reportFormats() {
             if (!config.booleanValue(REPORT_ENABLED, false)) {
-                return false;
+                return Set.of();
             }
-            String format = config.optionalString(REPORT_FORMAT, REPORT_FORMAT_JSON);
-            if (!REPORT_FORMAT_JSON.equalsIgnoreCase(format)) {
-                throw new IllegalArgumentException("Unsupported AOT report format '" + format + "'. Supported formats: " + REPORT_FORMAT_JSON);
+            List<String> configuredFormats = config.stringList(REPORT_FORMAT);
+            if (configuredFormats.isEmpty()) {
+                configuredFormats = List.of(REPORT_FORMAT_JSON);
             }
-            return true;
+            Set<String> reportFormats = new LinkedHashSet<>();
+            for (String configuredFormat : configuredFormats) {
+                String reportFormat = configuredFormat.toLowerCase(Locale.ENGLISH);
+                if (!REPORT_FORMAT_JSON.equals(reportFormat) && !REPORT_FORMAT_HTML.equals(reportFormat)) {
+                    throw new IllegalArgumentException("Unsupported AOT report format '" + configuredFormat + "'. Supported formats: " + REPORT_FORMAT_JSON + ", " + REPORT_FORMAT_HTML);
+                }
+                reportFormats.add(reportFormat);
+            }
+            return reportFormats;
         }
 
         private File reportDirectory() {
@@ -372,22 +419,6 @@ public final class MicronautAotOptimizer implements ConfigKeys {
             }
             return new File(outputDirectory, "reports");
         }
-    }
-
-    private void writeReport(DefaultSourceGenerationContext context,
-                             List<SourceGeneratorSelection> sourceGeneratorSelections,
-                             Set<String> environmentNames,
-                             File reportDirectory) {
-        Path reportPath = AotDiagnosticReportWriter.write(
-            reportDirectory.toPath(),
-            context.getRuntime(),
-            context.getPackageName(),
-            environmentNames,
-            sourceGeneratorSelections,
-            context,
-            VersionUtils.getMicronautVersion()
-        );
-        LOGGER.info("Micronaut AOT diagnostics report written to {}", reportPath.toAbsolutePath());
     }
 
 }

--- a/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
+++ b/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
@@ -63,6 +63,15 @@ public class Main implements Runnable, ConfigKeys {
     @Option(names = {"--output", "-o"}, description = "The output directory", required = false)
     private File outputDirectory;
 
+    @Option(names = {"--report"}, description = "Generate the JSON diagnostics report")
+    private boolean report;
+
+    @Option(names = {"--report-output"}, description = "The diagnostics report output directory")
+    private File reportOutputDirectory;
+
+    @Option(names = {"--report-format"}, description = "The diagnostics report format. Supported values: json")
+    private String reportFormat;
+
     @Override
     public void run() {
         configureSlf4j();
@@ -86,9 +95,21 @@ public class Main implements Runnable, ConfigKeys {
         if (outputDirectory != null) {
             props.put(OUTPUT_DIRECTORY, outputDirectory.getAbsolutePath());
         }
+        if (report) {
+            props.put(REPORT_ENABLED, "true");
+        }
+        if (reportOutputDirectory != null) {
+            props.put(REPORT_OUTPUT, reportOutputDirectory.getAbsolutePath());
+        }
+        if (reportFormat != null) {
+            props.put(REPORT_FORMAT, reportFormat);
+        }
         props.put(RUNTIME, runtime);
         URL[] urls = classpath.toArray(new URL[0]);
         executeInIsolatedLoader(props, urls, Thread.currentThread().getContextClassLoader());
+        if (outputDirectory != null && Boolean.parseBoolean(props.getProperty(REPORT_ENABLED))) {
+            System.out.println("Micronaut AOT diagnostics report written to " + reportFile(props).getAbsolutePath());
+        }
     }
 
     /**
@@ -151,6 +172,14 @@ public class Main implements Runnable, ConfigKeys {
 
     public static void main(String[] args) {
         System.exit(execute(args));
+    }
+
+    private File reportFile(Properties props) {
+        String reportOutput = props.getProperty(REPORT_OUTPUT);
+        File reportDirectory = reportOutput == null || reportOutput.isEmpty()
+                ? new File(outputDirectory, "reports")
+                : new File(reportOutput);
+        return new File(reportDirectory, REPORT_FILE_NAME);
     }
 
     private static class FilteringClassLoader extends ClassLoader {

--- a/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
+++ b/aot-cli/src/main/java/io/micronaut/aot/cli/Main.java
@@ -32,6 +32,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -63,13 +64,13 @@ public class Main implements Runnable, ConfigKeys {
     @Option(names = {"--output", "-o"}, description = "The output directory", required = false)
     private File outputDirectory;
 
-    @Option(names = {"--report"}, description = "Generate the JSON diagnostics report")
+    @Option(names = {"--report"}, description = "Generate diagnostics reports")
     private boolean report;
 
     @Option(names = {"--report-output"}, description = "The diagnostics report output directory")
     private File reportOutputDirectory;
 
-    @Option(names = {"--report-format"}, description = "The diagnostics report format. Supported values: json")
+    @Option(names = {"--report-format"}, description = "The diagnostics report format. Supported values: json, html")
     private String reportFormat;
 
     @Override
@@ -108,7 +109,9 @@ public class Main implements Runnable, ConfigKeys {
         URL[] urls = classpath.toArray(new URL[0]);
         executeInIsolatedLoader(props, urls, Thread.currentThread().getContextClassLoader());
         if (outputDirectory != null && Boolean.parseBoolean(props.getProperty(REPORT_ENABLED))) {
-            System.out.println("Micronaut AOT diagnostics report written to " + reportFile(props).getAbsolutePath());
+            for (File reportFile : reportFiles(props)) {
+                System.out.println("Micronaut AOT diagnostics report written to " + reportFile.getAbsolutePath());
+            }
         }
     }
 
@@ -174,12 +177,23 @@ public class Main implements Runnable, ConfigKeys {
         System.exit(execute(args));
     }
 
-    private File reportFile(Properties props) {
+    private List<File> reportFiles(Properties props) {
         String reportOutput = props.getProperty(REPORT_OUTPUT);
         File reportDirectory = reportOutput == null || reportOutput.isEmpty()
                 ? new File(outputDirectory, "reports")
                 : new File(reportOutput);
-        return new File(reportDirectory, REPORT_FILE_NAME);
+        return reportFormats(props).stream()
+                .map(format -> new File(reportDirectory, REPORT_FORMAT_HTML.equals(format) ? REPORT_HTML_FILE_NAME : REPORT_JSON_FILE_NAME))
+                .toList();
+    }
+
+    private static List<String> reportFormats(Properties props) {
+        String format = props.getProperty(REPORT_FORMAT, REPORT_FORMAT_JSON);
+        List<String> formats = Arrays.stream(format.split("[,;]\\s*"))
+                .filter(value -> !value.isBlank())
+                .map(value -> value.toLowerCase(Locale.ENGLISH))
+                .toList();
+        return formats.isEmpty() ? List.of(REPORT_FORMAT_JSON) : formats;
     }
 
     private static class FilteringClassLoader extends ClassLoader {

--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -65,6 +65,75 @@ class CliTest extends Specification {
         restoreSystemProperty(Main.SLF4J_PROVIDER, existingProvider)
     }
 
+    def "can generate a diagnostics report and print its path"() {
+        given:
+        def oldOut = System.out
+        def configFile = testDirectory.resolve("aot.properties")
+        Files.writeString(configFile, """cached.environment.enabled = true
+netty.machine.id = super-secret
+datasources.default.password = super-secret
+""")
+        def outputDirectory = testDirectory.resolve("output")
+        def classpath = System.getProperty('aot.runtime')
+        def stdout = new ByteArrayOutputStream()
+
+        when:
+        System.out = new PrintStream(stdout)
+        def exitCode = Main.execute(
+                '--classpath', classpath,
+                '--runtime', 'jit',
+                '--package', 'dummy',
+                '--config', configFile.toString(),
+                '--output', outputDirectory.toString(),
+                '--report'
+        )
+        System.out = oldOut
+        def reportFile = outputDirectory.resolve("reports/micronaut-aot-report.json")
+        def reportText = Files.readString(reportFile)
+
+        then:
+        exitCode == 0
+        stdout.toString().contains(reportFile.toFile().absolutePath)
+        Files.exists(reportFile)
+        !reportText.contains("super-secret")
+        reportText.contains('"schemaVersion": 1')
+        reportText.contains('"runtime": "JIT"')
+        reportText.contains('"packageName": "dummy"')
+        reportText.contains('"id": "cached.environment"')
+        reportText.contains('"enabled": true')
+        reportText.contains('"id": "netty.properties"')
+        reportText.contains('"key": "netty.machine.id"')
+        reportText.contains('"configured": true')
+        reportText.contains('"className": "dummy.AOTApplicationContextConfigurer"')
+        reportText.contains('"META-INF/services/io.micronaut.context.ApplicationContextConfigurer"')
+
+        cleanup:
+        if (oldOut != null) {
+            System.out = oldOut
+        }
+    }
+
+    def "does not generate a diagnostics report by default"() {
+        given:
+        def configFile = testDirectory.resolve("aot.properties")
+        Files.writeString(configFile, "cached.environment.enabled = true")
+        def outputDirectory = testDirectory.resolve("output")
+        def classpath = System.getProperty('aot.runtime')
+
+        when:
+        def exitCode = Main.execute(
+                '--classpath', classpath,
+                '--runtime', 'jit',
+                '--package', 'dummy',
+                '--config', configFile.toString(),
+                '--output', outputDirectory.toString()
+        )
+
+        then:
+        exitCode == 0
+        !Files.exists(outputDirectory.resolve("reports/micronaut-aot-report.json"))
+    }
+
     @Unroll
     def "can export a dummy configuration file"() {
         def configFile = testDirectory.resolve("${runtime}.properties")

--- a/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
+++ b/aot-cli/src/test/groovy/io/micronaut/aot/cli/CliTest.groovy
@@ -85,17 +85,23 @@ datasources.default.password = super-secret
                 '--package', 'dummy',
                 '--config', configFile.toString(),
                 '--output', outputDirectory.toString(),
-                '--report'
+                '--report',
+                '--report-format', 'json,html'
         )
         System.out = oldOut
         def reportFile = outputDirectory.resolve("reports/micronaut-aot-report.json")
+        def htmlReportFile = outputDirectory.resolve("reports/micronaut-aot-report.html")
         def reportText = Files.readString(reportFile)
+        def htmlReportText = Files.readString(htmlReportFile)
 
         then:
         exitCode == 0
         stdout.toString().contains(reportFile.toFile().absolutePath)
+        stdout.toString().contains(htmlReportFile.toFile().absolutePath)
         Files.exists(reportFile)
+        Files.exists(htmlReportFile)
         !reportText.contains("super-secret")
+        !htmlReportText.contains("super-secret")
         reportText.contains('"schemaVersion": 1')
         reportText.contains('"runtime": "JIT"')
         reportText.contains('"packageName": "dummy"')
@@ -106,6 +112,10 @@ datasources.default.password = super-secret
         reportText.contains('"configured": true')
         reportText.contains('"className": "dummy.AOTApplicationContextConfigurer"')
         reportText.contains('"META-INF/services/io.micronaut.context.ApplicationContextConfigurer"')
+        htmlReportText.contains("<title>Micronaut AOT Diagnostics Report</title>")
+        htmlReportText.contains("<td>JIT</td>")
+        htmlReportText.contains("<td>cached.environment</td>")
+        htmlReportText.contains("netty.machine.id (configured: true, redacted: true)")
 
         cleanup:
         if (oldOut != null) {

--- a/aot-core/src/main/java/io/micronaut/aot/core/config/SourceGeneratorLoader.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/config/SourceGeneratorLoader.java
@@ -55,30 +55,38 @@ public class SourceGeneratorLoader {
     @NonNull
     public static List<AOTCodeGenerator> load(Runtime runtime, AOTContext context) {
         Configuration configuration = context.getConfiguration();
+        return inspect(runtime, configuration)
+            .stream()
+            .filter(SourceGeneratorSelection::isEnabled)
+            .map(SourceGeneratorSelection::getGenerator)
+            .collect(Collectors.toList());
+    }
+
+    @NonNull
+    public static List<SourceGeneratorSelection> inspect(Runtime runtime, Configuration configuration) {
         return sourceGeneratorStream()
             .map(sg -> new Object() {
                 final AOTCodeGenerator generator = sg;
                 final AOTModule module = MetadataUtils.findMetadata(sg.getClass()).orElse(null);
             })
-            .filter(sg -> {
+            .map(sg -> {
                 if (sg.module != null) {
                     boolean isEnabledOnRuntime = MetadataUtils.isEnabledOn(runtime, sg.module);
                     if (!isEnabledOnRuntime) {
                         LOGGER.debug("Skipping source generator {} as it is not enabled on runtime {}", sg.generator.getClass().getName(), runtime);
-                        return false;
+                        return new SourceGeneratorSelection(sg.generator, sg.module, false, SourceGeneratorSelection.NOT_ENABLED_ON_RUNTIME);
                     }
                     boolean isEnabledByConfiguration = configuration.isFeatureEnabled(sg.module.id());
                     if (!isEnabledByConfiguration) {
                         LOGGER.debug("Skipping source generator {} as it is not enabled by configuration", sg.generator.getClass().getName());
-                        return false;
+                        return new SourceGeneratorSelection(sg.generator, sg.module, false, SourceGeneratorSelection.DISABLED_BY_CONFIGURATION);
                     }
                     LOGGER.debug("Loading source generator {}", sg.generator.getClass().getName());
-                    return true;
+                    return new SourceGeneratorSelection(sg.generator, sg.module, true, null);
                 }
-                return false;
+                return new SourceGeneratorSelection(sg.generator, null, false, SourceGeneratorSelection.MISSING_METADATA);
             })
-            .sorted(Comparator.comparing(f -> f.module, EXECUTION_ORDER))
-            .map(sg -> sg.generator)
+            .sorted(SourceGeneratorLoader::compareSelections)
             .collect(Collectors.toList());
     }
 
@@ -96,6 +104,21 @@ public class SourceGeneratorLoader {
 
     private static Stream<AOTCodeGenerator> sourceGeneratorStream() {
         return stream(ServiceLoader.load(AOTCodeGenerator.class).spliterator(), false);
+    }
+
+    static int compareSelections(SourceGeneratorSelection first, SourceGeneratorSelection second) {
+        AOTModule firstModule = first.getModule();
+        AOTModule secondModule = second.getModule();
+        if (firstModule != null && secondModule != null) {
+            return EXECUTION_ORDER.compare(firstModule, secondModule);
+        }
+        if (firstModule != null) {
+            return -1;
+        }
+        if (secondModule != null) {
+            return 1;
+        }
+        return first.getGenerator().getClass().getName().compareTo(second.getGenerator().getClass().getName());
     }
 
 }

--- a/aot-core/src/main/java/io/micronaut/aot/core/config/SourceGeneratorSelection.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/config/SourceGeneratorSelection.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aot.core.config;
+
+import io.micronaut.aot.core.AOTCodeGenerator;
+import io.micronaut.aot.core.AOTModule;
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Describes how a discovered source generator was selected for an AOT run.
+ */
+@Internal
+public final class SourceGeneratorSelection {
+    public static final String NOT_ENABLED_ON_RUNTIME = "not_enabled_on_runtime";
+    public static final String DISABLED_BY_CONFIGURATION = "disabled_by_configuration";
+    public static final String MISSING_METADATA = "missing_metadata";
+
+    private final AOTCodeGenerator generator;
+    private final AOTModule module;
+    private final boolean enabled;
+    private final String disabledReason;
+
+    public SourceGeneratorSelection(AOTCodeGenerator generator,
+                                    @Nullable AOTModule module,
+                                    boolean enabled,
+                                    @Nullable String disabledReason) {
+        this.generator = generator;
+        this.module = module;
+        this.enabled = enabled;
+        this.disabledReason = disabledReason;
+    }
+
+    public AOTCodeGenerator getGenerator() {
+        return generator;
+    }
+
+    @Nullable
+    public AOTModule getModule() {
+        return module;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Nullable
+    public String getDisabledReason() {
+        return disabledReason;
+    }
+}

--- a/aot-core/src/main/java/io/micronaut/aot/core/context/DefaultSourceGenerationContext.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/context/DefaultSourceGenerationContext.java
@@ -75,6 +75,7 @@ public final class DefaultSourceGenerationContext implements AOTContext {
     private final Configuration configuration;
     private final Map<Class<?>, Object> context = new HashMap<>();
     private final List<JavaFile> generatedJavaFiles = new ArrayList<>();
+    private final Set<String> generatedResources = new TreeSet<>();
     private final List<MethodSpec> initializers = new ArrayList<>();
     private final Path generatedResourcesDirectory;
     private final Set<String> buildTimeInitClasses = new HashSet<>();
@@ -204,6 +205,7 @@ public final class DefaultSourceGenerationContext implements AOTContext {
     @Override
     public void registerGeneratedResource(@NonNull String path, Consumer<? super File> consumer) {
         LOGGER.debug("Registering generated resource file: {}", path);
+        generatedResources.add(path);
         deferredOperations.add(() -> {
             Path relative = generatedResourcesDirectory.resolve(path);
             File resourceFile = relative.toFile();
@@ -248,6 +250,11 @@ public final class DefaultSourceGenerationContext implements AOTContext {
     @NonNull
     public Set<String> getExcludedResources() {
         return Collections.unmodifiableSet(excludedResources);
+    }
+
+    @NonNull
+    public Set<String> getGeneratedResources() {
+        return Collections.unmodifiableSet(generatedResources);
     }
 
     @NonNull

--- a/aot-core/src/main/java/io/micronaut/aot/core/report/AotDiagnosticReportWriter.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/report/AotDiagnosticReportWriter.java
@@ -42,9 +42,24 @@ import java.util.TreeSet;
  */
 @Internal
 public final class AotDiagnosticReportWriter {
-    public static final String REPORT_FILE_NAME = "micronaut-aot-report.json";
+    /**
+     * The fixed JSON diagnostics report file name.
+     */
+    public static final String JSON_REPORT_FILE_NAME = "micronaut-aot-report.json";
+    /**
+     * The fixed HTML diagnostics report file name.
+     */
+    public static final String HTML_REPORT_FILE_NAME = "micronaut-aot-report.html";
+    /**
+     * Backward-compatible alias for the JSON diagnostics report file name.
+     */
+    public static final String REPORT_FILE_NAME = JSON_REPORT_FILE_NAME;
     private static final int SCHEMA_VERSION = 1;
     private static final String CLASS_NAME = "className";
+    private static final String HTML_TABLE_START = "  <table>\n";
+    private static final String HTML_TABLE_END = "  </table>\n";
+    private static final String HTML_ROW_START = "    <tr>";
+    private static final String HTML_ROW_END = "</tr>\n";
 
     private AotDiagnosticReportWriter() {
     }
@@ -58,7 +73,7 @@ public final class AotDiagnosticReportWriter {
                              @Nullable String micronautVersion) {
         try {
             Files.createDirectories(outputDirectory);
-            Path report = outputDirectory.resolve(REPORT_FILE_NAME);
+            Path report = outputDirectory.resolve(JSON_REPORT_FILE_NAME);
             Files.writeString(
                 report,
                 toJson(runtime, packageName, activeEnvironments, sourceGenerators, context, micronautVersion),
@@ -67,6 +82,27 @@ public final class AotDiagnosticReportWriter {
             return report;
         } catch (IOException e) {
             throw new RuntimeException("Unable to write AOT diagnostics report to " + outputDirectory, e);
+        }
+    }
+
+    public static Path writeHtml(Path outputDirectory,
+                                 Runtime runtime,
+                                 String packageName,
+                                 Set<String> activeEnvironments,
+                                 List<SourceGeneratorSelection> sourceGenerators,
+                                 DefaultSourceGenerationContext context,
+                                 @Nullable String micronautVersion) {
+        try {
+            Files.createDirectories(outputDirectory);
+            Path report = outputDirectory.resolve(HTML_REPORT_FILE_NAME);
+            Files.writeString(
+                report,
+                toHtml(runtime, packageName, activeEnvironments, sourceGenerators, context, micronautVersion),
+                StandardCharsets.UTF_8
+            );
+            return report;
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to write AOT diagnostics HTML report to " + outputDirectory, e);
         }
     }
 
@@ -93,6 +129,47 @@ public final class AotDiagnosticReportWriter {
         appendDiagnostics(json, context.getDiagnostics());
         json.append("}\n");
         return json.toString();
+    }
+
+    public static String toHtml(Runtime runtime,
+                                String packageName,
+                                Set<String> activeEnvironments,
+                                List<SourceGeneratorSelection> sourceGenerators,
+                                DefaultSourceGenerationContext context,
+                                @Nullable String micronautVersion) {
+        var html = new StringBuilder(8192);
+        html.append("<!doctype html>\n");
+        html.append("<html lang=\"en\">\n<head>\n");
+        html.append("  <meta charset=\"utf-8\">\n");
+        html.append("  <title>Micronaut AOT Diagnostics Report</title>\n");
+        html.append("  <style>");
+        html.append("body{font-family:system-ui,sans-serif;margin:2rem;line-height:1.45;color:#1f2933}");
+        html.append("table{border-collapse:collapse;width:100%;margin:1rem 0 2rem}");
+        html.append("th,td{border:1px solid #d9e2ec;padding:.45rem;text-align:left;vertical-align:top}");
+        html.append("th{background:#f0f4f8}");
+        html.append("code{background:#f0f4f8;padding:.1rem .25rem;border-radius:3px}");
+        html.append(".muted{color:#52606d}");
+        html.append("</style>\n</head>\n<body>\n");
+        html.append("  <h1>Micronaut AOT Diagnostics Report</h1>\n");
+        html.append("  <p class=\"muted\">Configuration values are not included. Optimizer options show only keys and redaction state.</p>\n");
+        html.append("  <h2>Summary</h2>\n");
+        html.append(HTML_TABLE_START);
+        appendHtmlRow(html, "Schema version", String.valueOf(SCHEMA_VERSION));
+        appendHtmlRow(html, "Generated at", Instant.now().toString());
+        appendHtmlRow(html, "Micronaut version", micronautVersion);
+        appendHtmlRow(html, "Runtime", runtime.displayName());
+        appendHtmlRow(html, "Package", packageName);
+        appendHtmlRow(html, "Active environments", String.join(", ", new TreeSet<>(activeEnvironments)));
+        html.append(HTML_TABLE_END);
+        appendHtmlOptimizers(html, sourceGenerators, context);
+        appendHtmlGeneratedSources(html, context.getGeneratedJavaFiles());
+        appendHtmlList(html, "Generated Resources", context.getGeneratedResources());
+        appendHtmlList(html, "Filtered Resources", context.getExcludedResources());
+        appendHtmlExcludedServices(html, context.getExcludedServiceImplementations());
+        appendHtmlList(html, "Build-Time Initialization Classes", new TreeSet<>(context.getBuildTimeInitClasses()));
+        appendHtmlDiagnostics(html, context.getDiagnostics());
+        html.append("</body>\n</html>\n");
+        return html.toString();
     }
 
     private static void appendOptimizers(StringBuilder json,
@@ -203,6 +280,124 @@ public final class AotDiagnosticReportWriter {
             }
         }
         indent(json, 1).append("]\n");
+    }
+
+    private static void appendHtmlOptimizers(StringBuilder html,
+                                             List<SourceGeneratorSelection> sourceGenerators,
+                                             DefaultSourceGenerationContext context) {
+        html.append("  <h2>Optimizers</h2>\n");
+        html.append(HTML_TABLE_START);
+        html.append("    <tr><th>ID</th><th>Class</th><th>Description</th><th>Enabled</th><th>Disabled reason</th><th>Options</th><th>Dependencies</th><th>Runtimes</th></tr>\n");
+        for (SourceGeneratorSelection selection : sourceGenerators) {
+            AOTModule module = selection.getModule();
+            html.append(HTML_ROW_START);
+            appendHtmlCell(html, module == null ? null : module.id());
+            appendHtmlCell(html, selection.getGenerator().getClass().getName());
+            appendHtmlCell(html, module == null ? null : module.description());
+            appendHtmlCell(html, String.valueOf(selection.isEnabled()));
+            appendHtmlCell(html, selection.getDisabledReason());
+            appendHtmlCell(html, module == null ? "" : optionsSummary(module.options(), context));
+            appendHtmlCell(html, module == null ? "" : String.join(", ", module.dependencies()));
+            appendHtmlCell(html, module == null ? "" : String.join(", ", Arrays.stream(module.enabledOn()).map(Runtime::displayName).toList()));
+            html.append(HTML_ROW_END);
+        }
+        html.append(HTML_TABLE_END);
+    }
+
+    private static String optionsSummary(Option[] options, DefaultSourceGenerationContext context) {
+        return Arrays.stream(options)
+            .map(option -> option.key() + " (configured: " + context.getConfiguration().containsKey(option.key()) + ", redacted: " + context.getConfiguration().containsKey(option.key()) + ")")
+            .sorted()
+            .toList()
+            .toString();
+    }
+
+    private static void appendHtmlGeneratedSources(StringBuilder html, List<JavaFile> generatedJavaFiles) {
+        html.append("  <h2>Generated Sources</h2>\n");
+        html.append(HTML_TABLE_START);
+        html.append("    <tr><th>Class</th><th>Path</th></tr>\n");
+        for (JavaFile javaFile : generatedJavaFiles) {
+            String className = javaFile.packageName + "." + javaFile.typeSpec.name;
+            html.append(HTML_ROW_START);
+            appendHtmlCell(html, className);
+            appendHtmlCell(html, className.replace('.', '/') + ".java");
+            html.append(HTML_ROW_END);
+        }
+        html.append(HTML_TABLE_END);
+    }
+
+    private static void appendHtmlList(StringBuilder html, String title, Collection<String> values) {
+        html.append("  <h2>").append(escapeHtml(title)).append("</h2>\n");
+        html.append("  <ul>\n");
+        for (String value : values) {
+            html.append("    <li><code>").append(escapeHtml(value)).append("</code></li>\n");
+        }
+        html.append("  </ul>\n");
+    }
+
+    private static void appendHtmlExcludedServices(StringBuilder html, Map<String, String> excludedServiceImplementations) {
+        html.append("  <h2>Excluded Service Implementations</h2>\n");
+        html.append(HTML_TABLE_START);
+        html.append("    <tr><th>Class</th><th>Reason</th></tr>\n");
+        excludedServiceImplementations.entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEach(entry -> {
+                html.append(HTML_ROW_START);
+                appendHtmlCell(html, entry.getKey());
+                appendHtmlCell(html, entry.getValue());
+                html.append(HTML_ROW_END);
+            });
+        html.append(HTML_TABLE_END);
+    }
+
+    private static void appendHtmlDiagnostics(StringBuilder html, Map<String, List<String>> diagnostics) {
+        html.append("  <h2>Diagnostics</h2>\n");
+        html.append(HTML_TABLE_START);
+        html.append("    <tr><th>Category</th><th>Message</th></tr>\n");
+        diagnostics.entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEach(entry -> entry.getValue()
+                .stream()
+                .sorted(Comparator.naturalOrder())
+                .forEach(message -> {
+                    html.append(HTML_ROW_START);
+                    appendHtmlCell(html, entry.getKey());
+                    appendHtmlCell(html, message);
+                    html.append(HTML_ROW_END);
+                }));
+        html.append(HTML_TABLE_END);
+    }
+
+    private static void appendHtmlRow(StringBuilder html, String name, @Nullable String value) {
+        html.append("    <tr><th>");
+        html.append(escapeHtml(name));
+        html.append("</th>");
+        appendHtmlCell(html, value);
+        html.append(HTML_ROW_END);
+    }
+
+    private static void appendHtmlCell(StringBuilder html, @Nullable String value) {
+        html.append("<td>");
+        html.append(escapeHtml(value == null ? "" : value));
+        html.append("</td>");
+    }
+
+    private static String escapeHtml(String value) {
+        var escaped = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '&' -> escaped.append("&amp;");
+                case '<' -> escaped.append("&lt;");
+                case '>' -> escaped.append("&gt;");
+                case '"' -> escaped.append("&quot;");
+                case '\'' -> escaped.append("&#39;");
+                default -> escaped.append(c);
+            }
+        }
+        return escaped.toString();
     }
 
     private static void appendStringArray(StringBuilder json,

--- a/aot-core/src/main/java/io/micronaut/aot/core/report/AotDiagnosticReportWriter.java
+++ b/aot-core/src/main/java/io/micronaut/aot/core/report/AotDiagnosticReportWriter.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aot.core.report;
+
+import com.squareup.javapoet.JavaFile;
+import io.micronaut.aot.core.AOTModule;
+import io.micronaut.aot.core.Option;
+import io.micronaut.aot.core.Runtime;
+import io.micronaut.aot.core.config.SourceGeneratorSelection;
+import io.micronaut.aot.core.context.DefaultSourceGenerationContext;
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Writes the structured Micronaut AOT diagnostics report.
+ */
+@Internal
+public final class AotDiagnosticReportWriter {
+    public static final String REPORT_FILE_NAME = "micronaut-aot-report.json";
+    private static final int SCHEMA_VERSION = 1;
+    private static final String CLASS_NAME = "className";
+
+    private AotDiagnosticReportWriter() {
+    }
+
+    public static Path write(Path outputDirectory,
+                             Runtime runtime,
+                             String packageName,
+                             Set<String> activeEnvironments,
+                             List<SourceGeneratorSelection> sourceGenerators,
+                             DefaultSourceGenerationContext context,
+                             @Nullable String micronautVersion) {
+        try {
+            Files.createDirectories(outputDirectory);
+            Path report = outputDirectory.resolve(REPORT_FILE_NAME);
+            Files.writeString(
+                report,
+                toJson(runtime, packageName, activeEnvironments, sourceGenerators, context, micronautVersion),
+                StandardCharsets.UTF_8
+            );
+            return report;
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to write AOT diagnostics report to " + outputDirectory, e);
+        }
+    }
+
+    public static String toJson(Runtime runtime,
+                                String packageName,
+                                Set<String> activeEnvironments,
+                                List<SourceGeneratorSelection> sourceGenerators,
+                                DefaultSourceGenerationContext context,
+                                @Nullable String micronautVersion) {
+        var json = new StringBuilder(4096);
+        json.append("{\n");
+        appendNumber(json, 1, "schemaVersion", SCHEMA_VERSION, true);
+        appendString(json, 1, "generatedAt", Instant.now().toString(), true);
+        appendString(json, 1, "micronautVersion", micronautVersion, true);
+        appendString(json, 1, "runtime", runtime.displayName(), true);
+        appendString(json, 1, "packageName", packageName, true);
+        appendStringArray(json, 1, "activeEnvironments", new TreeSet<>(activeEnvironments), true);
+        appendOptimizers(json, sourceGenerators, context);
+        appendGeneratedSources(json, context.getGeneratedJavaFiles());
+        appendStringArray(json, 1, "generatedResources", context.getGeneratedResources(), true);
+        appendStringArray(json, 1, "filteredResources", context.getExcludedResources(), true);
+        appendExcludedServices(json, context.getExcludedServiceImplementations());
+        appendStringArray(json, 1, "buildTimeInitClasses", new TreeSet<>(context.getBuildTimeInitClasses()), true);
+        appendDiagnostics(json, context.getDiagnostics());
+        json.append("}\n");
+        return json.toString();
+    }
+
+    private static void appendOptimizers(StringBuilder json,
+                                         List<SourceGeneratorSelection> sourceGenerators,
+                                         DefaultSourceGenerationContext context) {
+        indent(json, 1).append("\"optimizers\": [\n");
+        for (int i = 0; i < sourceGenerators.size(); i++) {
+            SourceGeneratorSelection selection = sourceGenerators.get(i);
+            AOTModule module = selection.getModule();
+            indent(json, 2).append("{\n");
+            appendString(json, 3, "id", module == null ? null : module.id(), true);
+            appendString(json, 3, CLASS_NAME, selection.getGenerator().getClass().getName(), true);
+            appendString(json, 3, "description", module == null ? null : module.description(), true);
+            appendBoolean(json, 3, "enabled", selection.isEnabled(), true);
+            appendString(json, 3, "disabledReason", selection.getDisabledReason(), true);
+            appendOptions(json, module == null ? new Option[0] : module.options(), context);
+            appendStringArray(json, 3, "dependencies", module == null ? List.of() : Arrays.asList(module.dependencies()), true);
+            appendStringArray(json, 3, "enabledRuntimes", module == null
+                ? List.of()
+                : Arrays.stream(module.enabledOn()).map(Runtime::displayName).toList(), false);
+            indent(json, 2).append("}");
+            if (i < sourceGenerators.size() - 1) {
+                json.append(",");
+            }
+            json.append("\n");
+        }
+        indent(json, 1).append("],\n");
+    }
+
+    private static void appendOptions(StringBuilder json, Option[] options, DefaultSourceGenerationContext context) {
+        indent(json, 3).append("\"options\": [\n");
+        for (int i = 0; i < options.length; i++) {
+            Option option = options[i];
+            boolean configured = context.getConfiguration().containsKey(option.key());
+            indent(json, 4).append("{\n");
+            appendString(json, 5, "key", option.key(), true);
+            appendBoolean(json, 5, "configured", configured, true);
+            appendBoolean(json, 5, "redacted", configured, false);
+            indent(json, 4).append("}");
+            if (i < options.length - 1) {
+                json.append(",");
+            }
+            json.append("\n");
+        }
+        indent(json, 3).append("],\n");
+    }
+
+    private static void appendGeneratedSources(StringBuilder json, List<JavaFile> generatedJavaFiles) {
+        indent(json, 1).append("\"generatedSources\": [\n");
+        for (int i = 0; i < generatedJavaFiles.size(); i++) {
+            JavaFile javaFile = generatedJavaFiles.get(i);
+            String className = javaFile.packageName + "." + javaFile.typeSpec.name;
+            indent(json, 2).append("{\n");
+            appendString(json, 3, CLASS_NAME, className, true);
+            appendString(json, 3, "path", className.replace('.', '/') + ".java", false);
+            indent(json, 2).append("}");
+            if (i < generatedJavaFiles.size() - 1) {
+                json.append(",");
+            }
+            json.append("\n");
+        }
+        indent(json, 1).append("],\n");
+    }
+
+    private static void appendExcludedServices(StringBuilder json, Map<String, String> excludedServiceImplementations) {
+        indent(json, 1).append("\"excludedServiceImplementations\": [\n");
+        List<Map.Entry<String, String>> entries = excludedServiceImplementations.entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .toList();
+        for (int i = 0; i < entries.size(); i++) {
+            Map.Entry<String, String> entry = entries.get(i);
+            indent(json, 2).append("{\n");
+            appendString(json, 3, CLASS_NAME, entry.getKey(), true);
+            appendString(json, 3, "reason", entry.getValue(), false);
+            indent(json, 2).append("}");
+            if (i < entries.size() - 1) {
+                json.append(",");
+            }
+            json.append("\n");
+        }
+        indent(json, 1).append("],\n");
+    }
+
+    private static void appendDiagnostics(StringBuilder json, Map<String, List<String>> diagnostics) {
+        indent(json, 1).append("\"diagnostics\": [\n");
+        List<Map.Entry<String, List<String>>> entries = diagnostics.entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .toList();
+        int total = entries.stream().mapToInt(entry -> entry.getValue().size()).sum();
+        int written = 0;
+        for (Map.Entry<String, List<String>> entry : entries) {
+            List<String> messages = entry.getValue()
+                .stream()
+                .sorted(Comparator.naturalOrder())
+                .toList();
+            for (String message : messages) {
+                indent(json, 2).append("{\n");
+                appendString(json, 3, "category", entry.getKey(), true);
+                appendString(json, 3, "message", message, false);
+                indent(json, 2).append("}");
+                written++;
+                if (written < total) {
+                    json.append(",");
+                }
+                json.append("\n");
+            }
+        }
+        indent(json, 1).append("]\n");
+    }
+
+    private static void appendStringArray(StringBuilder json,
+                                          int depth,
+                                          String name,
+                                          Collection<String> values,
+                                          boolean comma) {
+        indent(json, depth).append('"').append(name).append("\": [");
+        int i = 0;
+        for (String value : values) {
+            if (i > 0) {
+                json.append(", ");
+            }
+            appendQuoted(json, value);
+            i++;
+        }
+        json.append("]");
+        appendCommaAndNewLine(json, comma);
+    }
+
+    private static void appendString(StringBuilder json, int depth, String name, @Nullable String value, boolean comma) {
+        indent(json, depth).append('"').append(name).append("\": ");
+        if (value == null) {
+            json.append("null");
+        } else {
+            appendQuoted(json, value);
+        }
+        appendCommaAndNewLine(json, comma);
+    }
+
+    private static void appendNumber(StringBuilder json, int depth, String name, int value, boolean comma) {
+        indent(json, depth).append('"').append(name).append("\": ").append(value);
+        appendCommaAndNewLine(json, comma);
+    }
+
+    private static void appendBoolean(StringBuilder json, int depth, String name, boolean value, boolean comma) {
+        indent(json, depth).append('"').append(name).append("\": ").append(value);
+        appendCommaAndNewLine(json, comma);
+    }
+
+    private static void appendQuoted(StringBuilder json, String value) {
+        json.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"' -> json.append("\\\"");
+                case '\\' -> json.append("\\\\");
+                case '\b' -> json.append("\\b");
+                case '\f' -> json.append("\\f");
+                case '\n' -> json.append("\\n");
+                case '\r' -> json.append("\\r");
+                case '\t' -> json.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        json.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        json.append(c);
+                    }
+                }
+            }
+        }
+        json.append('"');
+    }
+
+    private static StringBuilder indent(StringBuilder json, int depth) {
+        return json.append("  ".repeat(depth));
+    }
+
+    private static void appendCommaAndNewLine(StringBuilder json, boolean comma) {
+        if (comma) {
+            json.append(",");
+        }
+        json.append("\n");
+    }
+}

--- a/aot-core/src/test/groovy/io/micronaut/aot/core/config/SourceGeneratorLoaderTest.groovy
+++ b/aot-core/src/test/groovy/io/micronaut/aot/core/config/SourceGeneratorLoaderTest.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.aot.core.config
+
+import io.micronaut.aot.core.AOTCodeGenerator
+import io.micronaut.aot.core.AOTContext
+import io.micronaut.aot.core.AOTModule
+import spock.lang.Specification
+
+class SourceGeneratorLoaderTest extends Specification {
+
+    def "sorts missing metadata selections after metadata-backed selections"() {
+        given:
+        def first = selection(new FirstGenerator(), false)
+        def second = selection(new SecondGenerator(), true)
+        def missing = new SourceGeneratorSelection(new MissingMetadataGenerator(), null, false, SourceGeneratorSelection.MISSING_METADATA)
+
+        when:
+        def sorted = [missing, second, first].sort(SourceGeneratorLoader::compareSelections)
+
+        then:
+        sorted*.generator*.class == [FirstGenerator, SecondGenerator, MissingMetadataGenerator]
+    }
+
+    private static SourceGeneratorSelection selection(AOTCodeGenerator generator, boolean enabled) {
+        def module = generator.class.getAnnotation(AOTModule)
+        new SourceGeneratorSelection(generator, module, enabled, enabled ? null : SourceGeneratorSelection.DISABLED_BY_CONFIGURATION)
+    }
+
+    @AOTModule(id = "first")
+    private static class FirstGenerator implements AOTCodeGenerator {
+        @Override
+        void generate(AOTContext context) {
+        }
+    }
+
+    @AOTModule(id = "second", dependencies = ["first"])
+    private static class SecondGenerator implements AOTCodeGenerator {
+        @Override
+        void generate(AOTContext context) {
+        }
+    }
+
+    private static class MissingMetadataGenerator implements AOTCodeGenerator {
+        @Override
+        void generate(AOTContext context) {
+        }
+    }
+}

--- a/aot-core/src/test/groovy/io/micronaut/aot/core/context/DefaultSourceGenerationContextTest.groovy
+++ b/aot-core/src/test/groovy/io/micronaut/aot/core/context/DefaultSourceGenerationContextTest.groovy
@@ -19,16 +19,16 @@ class DefaultSourceGenerationContextTest extends AbstractSourceGeneratorSpec {
     def "test parallel diagnostic add"() {
         when:
 
-        def threadsCount = 50;
+        def threadsCount = 50
 
-        List<Callable<Object>> tasks = new ArrayList<>(threadsCount);
+        List<Callable<Object>> tasks = new ArrayList<>(threadsCount)
         for (int i = 0; i < threadsCount; i++) {
-            tasks.add(addDiagnostics("category", "message"));
-            tasks.add(addDiagnostics("category2", "message2"));
-            tasks.add(addDiagnostics("category3", "message3"));
+            tasks.add(addDiagnostics("category", "message"))
+            tasks.add(addDiagnostics("category2", "message2"))
+            tasks.add(addDiagnostics("category3", "message3"))
         }
 
-        def executorService = Executors.newFixedThreadPool(8);
+        def executorService = Executors.newFixedThreadPool(8)
         executorService.invokeAll(tasks)
 
         then:
@@ -48,8 +48,8 @@ class DefaultSourceGenerationContextTest extends AbstractSourceGeneratorSpec {
     }
 
     Callable<Object> addDiagnostics(String category, String message) {
-        return Executors.callable(() -> {
+        return Executors.callable({
             context.addDiagnostics(category, message)
-        })
+        } as Runnable)
     }
 }

--- a/aot-core/src/test/groovy/io/micronaut/aot/core/context/DefaultSourceGenerationContextTest.groovy
+++ b/aot-core/src/test/groovy/io/micronaut/aot/core/context/DefaultSourceGenerationContextTest.groovy
@@ -39,6 +39,14 @@ class DefaultSourceGenerationContextTest extends AbstractSourceGeneratorSpec {
         context.diagnostics.category3.size() == 50
     }
 
+    def "tracks generated resources for diagnostics reporting"() {
+        when:
+        context.registerGeneratedResource("META-INF/test/resource.txt") {}
+
+        then:
+        context.generatedResources == ["META-INF/test/resource.txt"] as Set
+    }
+
     Callable<Object> addDiagnostics(String category, String message) {
         return Executors.callable(() -> {
             context.addDiagnostics(category, message)

--- a/aot-core/src/test/groovy/io/micronaut/aot/core/report/AotDiagnosticReportWriterTest.groovy
+++ b/aot-core/src/test/groovy/io/micronaut/aot/core/report/AotDiagnosticReportWriterTest.groovy
@@ -71,6 +71,46 @@ class AotDiagnosticReportWriterTest extends Specification {
         report.contains('"message": "message with \\"quotes\\""')
     }
 
+    def "writes html report with escaped diagnostics and redacted option state"() {
+        given:
+        def props = new Properties()
+        props.put("sample.password", "super-secret")
+        def context = new DefaultSourceGenerationContext(
+                "example",
+                ApplicationContextAnalyzer.create {},
+                new DefaultConfiguration(props),
+                testDirectory.resolve("resources")
+        )
+        context.registerGeneratedSourceFile(context.javaFile(TypeSpec.classBuilder("GeneratedType").addModifiers(Modifier.PUBLIC).build()))
+        context.registerGeneratedResource("META-INF/example/resource.txt") {}
+        context.registerExcludedResource("application.yml")
+        context.registerBuildTimeInit("example.NativeType")
+        context.addDiagnostics("sample", "message with <markup> & \"quotes\"")
+        def module = MetadataGenerator.getAnnotation(AOTModule)
+        def selection = new SourceGeneratorSelection(new MetadataGenerator(), module, true, null)
+
+        when:
+        def report = AotDiagnosticReportWriter.toHtml(
+                Runtime.JIT,
+                "example",
+                ["test"] as Set,
+                [selection],
+                context,
+                "1.2.3"
+        )
+
+        then:
+        !report.contains("super-secret")
+        report.contains("<title>Micronaut AOT Diagnostics Report</title>")
+        report.contains("<td>JIT</td>")
+        report.contains("<td>example</td>")
+        report.contains("<td>metadata-generator</td>")
+        report.contains("sample.password (configured: true, redacted: true)")
+        report.contains("example/GeneratedType.java")
+        report.contains("META-INF/example/resource.txt")
+        report.contains("message with &lt;markup&gt; &amp; &quot;quotes&quot;")
+    }
+
     def "writes report file to requested directory"() {
         given:
         def context = new DefaultSourceGenerationContext(
@@ -95,6 +135,32 @@ class AotDiagnosticReportWriterTest extends Specification {
         reportFile.fileName.toString() == "micronaut-aot-report.json"
         Files.exists(reportFile)
         reportFile.toFile().text.contains('"runtime": "native"')
+    }
+
+    def "writes html report file to requested directory"() {
+        given:
+        def context = new DefaultSourceGenerationContext(
+                "example",
+                ApplicationContextAnalyzer.create {},
+                new DefaultConfiguration(new Properties()),
+                testDirectory.resolve("resources")
+        )
+
+        when:
+        def reportFile = AotDiagnosticReportWriter.writeHtml(
+                testDirectory.resolve("nested/reports"),
+                Runtime.NATIVE,
+                "example",
+                [] as Set,
+                [],
+                context,
+                null
+        )
+
+        then:
+        reportFile.fileName.toString() == "micronaut-aot-report.html"
+        Files.exists(reportFile)
+        reportFile.toFile().text.contains("<td>native</td>")
     }
 
     @AOTModule(

--- a/aot-core/src/test/groovy/io/micronaut/aot/core/report/AotDiagnosticReportWriterTest.groovy
+++ b/aot-core/src/test/groovy/io/micronaut/aot/core/report/AotDiagnosticReportWriterTest.groovy
@@ -1,0 +1,110 @@
+package io.micronaut.aot.core.report
+
+import com.squareup.javapoet.TypeSpec
+import io.micronaut.aot.core.AOTCodeGenerator
+import io.micronaut.aot.core.AOTContext
+import io.micronaut.aot.core.AOTModule
+import io.micronaut.aot.core.Option
+import io.micronaut.aot.core.Runtime
+import io.micronaut.aot.core.config.DefaultConfiguration
+import io.micronaut.aot.core.config.SourceGeneratorSelection
+import io.micronaut.aot.core.context.ApplicationContextAnalyzer
+import io.micronaut.aot.core.context.DefaultSourceGenerationContext
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import javax.lang.model.element.Modifier
+import java.nio.file.Files
+import java.nio.file.Path
+
+class AotDiagnosticReportWriterTest extends Specification {
+    @TempDir
+    Path testDirectory
+
+    def "writes tracked artifacts and redacts configured option values"() {
+        given:
+        def props = new Properties()
+        props.put("sample.password", "super-secret")
+        def context = new DefaultSourceGenerationContext(
+                "example",
+                ApplicationContextAnalyzer.create {},
+                new DefaultConfiguration(props),
+                testDirectory.resolve("resources")
+        )
+        context.registerGeneratedSourceFile(context.javaFile(TypeSpec.classBuilder("GeneratedType").addModifiers(Modifier.PUBLIC).build()))
+        context.registerGeneratedResource("META-INF/example/resource.txt") {}
+        context.registerExcludedResource("application.yml")
+        context.registerExcludedServiceImpl("example.Service", "replaced by generated implementation")
+        context.registerBuildTimeInit("example.NativeType")
+        context.addDiagnostics("sample", "message with \"quotes\"")
+        def module = MetadataGenerator.getAnnotation(AOTModule)
+        def selection = new SourceGeneratorSelection(new MetadataGenerator(), module, true, null)
+
+        when:
+        def report = AotDiagnosticReportWriter.toJson(
+                Runtime.JIT,
+                "example",
+                ["test"] as Set,
+                [selection],
+                context,
+                "1.2.3"
+        )
+
+        then:
+        !report.contains("super-secret")
+        report.contains('"schemaVersion": 1')
+        report.contains('"runtime": "JIT"')
+        report.contains('"packageName": "example"')
+        report.contains('"activeEnvironments": ["test"]')
+        report.contains('"id": "metadata-generator"')
+        report.contains('"enabled": true')
+        report.contains('"key": "sample.password"')
+        report.contains('"configured": true')
+        report.contains('"redacted": true')
+        report.contains('"className": "example.GeneratedType"')
+        report.contains('"path": "example/GeneratedType.java"')
+        report.contains('"generatedResources": ["META-INF/example/resource.txt"]')
+        report.contains('"filteredResources": ["application.yml"]')
+        report.contains('"className": "example.Service"')
+        report.contains('"buildTimeInitClasses": ["example.NativeType"]')
+        report.contains('"category": "sample"')
+        report.contains('"message": "message with \\"quotes\\""')
+    }
+
+    def "writes report file to requested directory"() {
+        given:
+        def context = new DefaultSourceGenerationContext(
+                "example",
+                ApplicationContextAnalyzer.create {},
+                new DefaultConfiguration(new Properties()),
+                testDirectory.resolve("resources")
+        )
+
+        when:
+        def reportFile = AotDiagnosticReportWriter.write(
+                testDirectory.resolve("nested/reports"),
+                Runtime.NATIVE,
+                "example",
+                [] as Set,
+                [],
+                context,
+                null
+        )
+
+        then:
+        reportFile.fileName.toString() == "micronaut-aot-report.json"
+        Files.exists(reportFile)
+        reportFile.toFile().text.contains('"runtime": "native"')
+    }
+
+    @AOTModule(
+            id = "metadata-generator",
+            description = "Test generator",
+            options = [@Option(key = "sample.password", description = "Sensitive sample")]
+    )
+    private static class MetadataGenerator implements AOTCodeGenerator {
+        @Override
+        void generate(AOTContext context) {
+        }
+    }
+}

--- a/src/main/docs/guide/diagnosticsReport.adoc
+++ b/src/main/docs/guide/diagnosticsReport.adoc
@@ -1,0 +1,93 @@
+Micronaut AOT can write a structured diagnostics report for build tools and CI systems.
+The report is disabled by default and does not change generated sources, generated resources, or log files unless it is enabled.
+
+Enable the report with the following configuration property:
+
+[source,properties]
+----
+micronaut.aot.report.enabled=true
+----
+
+When the CLI is used for an AOT run, the same behavior can be enabled with:
+
+[source,bash]
+----
+micronaut-aot --classpath app.jar --runtime jit --package example.aot --config aot.properties --output build/aot --report
+----
+
+The default output file is:
+
+[source]
+----
+<output.directory>/reports/micronaut-aot-report.json
+----
+
+Use `micronaut.aot.report.output` or `--report-output` to select a different report directory.
+Micronaut AOT always writes the fixed file name `micronaut-aot-report.json` inside that directory.
+
+The only supported report format is JSON.
+The default value is:
+
+[source,properties]
+----
+micronaut.aot.report.format=json
+----
+
+Unsupported formats fail the AOT run with a configuration error.
+
+The JSON report uses a versioned schema.
+Version 1 includes:
+
+* `schemaVersion`
+* `generatedAt`
+* `micronautVersion`
+* `runtime`
+* `packageName`
+* `activeEnvironments`
+* `optimizers`, including optimizer id, implementation class, description, enabled state, disabled reason, option keys, dependency ids, and supported runtimes
+* `generatedSources`
+* `generatedResources`
+* `filteredResources`
+* `excludedServiceImplementations`
+* `buildTimeInitClasses`
+* `diagnostics`
+
+Example:
+
+[source,json]
+----
+{
+  "schemaVersion": 1,
+  "runtime": "JIT",
+  "packageName": "example.aot",
+  "optimizers": [
+    {
+      "id": "netty.properties",
+      "enabled": true,
+      "options": [
+        {
+          "key": "netty.machine.id",
+          "configured": true,
+          "redacted": true
+        }
+      ]
+    }
+  ],
+  "generatedSources": [
+    {
+      "className": "example.aot.AOTApplicationContextConfigurer",
+      "path": "example/aot/AOTApplicationContextConfigurer.java"
+    }
+  ],
+  "generatedResources": [
+    "META-INF/services/io.micronaut.context.ApplicationContextConfigurer"
+  ]
+}
+----
+
+Configuration values are not written to the report.
+Optimizer options only show the option key, whether the key was configured, and whether the value was redacted.
+This prevents common secrets such as passwords, tokens, credentials, and datasource values from being copied into diagnostics artifacts by default.
+
+Build-tool integrations can enable the report property for an AOT invocation and publish the printed report path or the JSON file as a build artifact.
+Existing log files remain available for human-readable diagnostics.

--- a/src/main/docs/guide/diagnosticsReport.adoc
+++ b/src/main/docs/guide/diagnosticsReport.adoc
@@ -23,15 +23,22 @@ The default output file is:
 ----
 
 Use `micronaut.aot.report.output` or `--report-output` to select a different report directory.
-Micronaut AOT always writes the fixed file name `micronaut-aot-report.json` inside that directory.
+Micronaut AOT writes fixed file names inside that directory.
 
-The only supported report format is JSON.
+The default report format is JSON.
 The default value is:
 
 [source,properties]
 ----
 micronaut.aot.report.format=json
 ----
+
+Set `micronaut.aot.report.format=html` or `micronaut.aot.report.format=json,html` to write an HTML report.
+The CLI accepts the same values with `--report-format`.
+The fixed output file names are:
+
+* `micronaut-aot-report.json`
+* `micronaut-aot-report.html`
 
 Unsupported formats fail the AOT run with a configuration error.
 
@@ -90,4 +97,5 @@ Optimizer options only show the option key, whether the key was configured, and 
 This prevents common secrets such as passwords, tokens, credentials, and datasource values from being copied into diagnostics artifacts by default.
 
 Build-tool integrations can enable the report property for an AOT invocation and publish the printed report path or the JSON file as a build artifact.
-Existing log files remain available for human-readable diagnostics.
+When HTML is enabled, integrations can also publish `micronaut-aot-report.html` as a human-readable build artifact.
+Existing log files remain available for detailed diagnostics.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -4,4 +4,6 @@ releaseHistory: Release History
 quickStart:
   title: Quick Start
 standardOptimizers: Standard Optimizers
+diagnosticsReport:
+  title: Diagnostics Report
 repository: Repository


### PR DESCRIPTION
## Summary

- Adds an opt-in JSON Micronaut AOT diagnostics report with schema versioning, runtime/environment metadata, optimizer selection details, generated artifacts, filtered resources, build-time init classes, excluded services, and diagnostics.
- Adds report configuration keys and CLI flags for enabling the report, selecting a report directory, and validating the JSON-only format.
- Documents diagnostics report usage and adds focused tests for report generation, disabled-by-default behavior, generated resource tracking, source-generator selection ordering, JSON escaping, and value redaction.

## Issue Linkage

Paperclip issue: DEV-319.

No linked GitHub issue is recorded for this Paperclip-originated enhancement, so there is no GitHub issue closing keyword or issue-author reviewer to apply.

## Release Projects

Please associate this PR with the Micronaut organization projects `5.0.0-M3` and `5.0.0 Release`.

Ambiguity note: the AOT repository does not expose an explicit platform-consumption mapping in checked files; this project selection is inferred from the `3.0.x` branch/release timing and the currently open public Micronaut organization release boards.

## Verification

```bash
./gradlew :micronaut-aot-core:test :micronaut-aot-api:compileJava :micronaut-aot-cli:test --tests '*AotDiagnosticReportWriterTest' --tests '*DefaultSourceGenerationContextTest' --tests '*SourceGeneratorLoaderTest' --tests '*CliTest' -q
./gradlew -q docs
git diff --check origin/3.0.x..HEAD
./gradlew -q spotlessCheck
```

---
###### ✨ This message was AI-generated using gpt-5