### PR TITLE
docs: check contributing guidelines before PR handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,16 @@ that owns the behavior.
   JIT and native runtime paths when changing `Runtime`, GraalVM configuration,
   service loading, environment deduction, or application-context configuration.
 
+## Contributing Guidelines
+
+- Before opening or updating a pull request, read this repository's
+  `CONTRIBUTING.md` and follow every repo-specific PR requirement it names.
+- Treat contributor-checklist items as handoff requirements. If a requirement is
+  not applicable, state that explicitly in the PR description or handoff note.
+- For UI-visible changes, confirm whether screenshots or other visual evidence
+  are required and include them in the PR description; if screenshots cannot be
+  provided, explain why and describe the verification that was performed.
+
 ## Documentation
 
 - Guide files live under `src/main/docs/guide`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,11 @@ that owns the behavior.
 ## Contributing Guidelines
 
 - Before opening or updating a pull request, read this repository's
-  `CONTRIBUTING.md` and follow every repo-specific PR requirement it names.
-- Treat contributor-checklist items as handoff requirements. If a requirement is
-  not applicable, state that explicitly in the PR description or handoff note.
+  `CONTRIBUTING.md` and any maintainer guidance such as `MAINTAINING.md` when
+  present, then follow every repo-specific PR requirement they name.
+- Treat requirements in contributor docs and any PR template checklist items, if
+  present, as handoff requirements. If a requirement is not applicable, state
+  that explicitly in the PR description or handoff note.
 - For UI-visible changes, confirm whether screenshots or other visual evidence
   are required and include them in the PR description; if screenshots cannot be
   provided, explain why and describe the verification that was performed.


### PR DESCRIPTION
## Summary
- Add a root `AGENTS.md` check to read repository `CONTRIBUTING.md` or maintainer contribution guidance before PR handoff.
- Require agents to treat contributor checklist items as handoff requirements.
- Call out UI-visible changes so screenshots or equivalent visual evidence are included when repository guidance requires them.

## Validation
- `git diff --check`

## CI
- Commit uses `[skip ci]` because this changes only Markdown agent guidance that repository builds do not exercise.

Paperclip: DEV-349

---
###### ✨ This message was AI-generated using gpt-5.5
