### PR TITLE
Fix generated optimizer docs warning spacing

### DIFF
--- a/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
+++ b/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
@@ -38,8 +38,8 @@ public class ConfigPropsGenerator {
                     SourceGeneratorLoader.list(Runtime.NATIVE).stream()
                 ).distinct()
                 .toList();
-            writer.println("WARNING: These are not configuration properties to add in your regular Micronaut configuration files," +
-                           "but properties to be added to the Micronaut AOT configuration, via your build plugin." +
+            writer.println("WARNING: These are not configuration properties to add in your regular Micronaut configuration files, " +
+                           "but properties to be added to the Micronaut AOT configuration, via your build plugin. " +
                            "Please refer to the appropriate Maven or Gradle plugin for more details.");
             writer.println();
             for (AOTModule module : codeGenerators) {


### PR DESCRIPTION
## Summary

- Fix spacing in the generated Standard Optimizers warning paragraph.
- Keep the generated configuration reference prose readable in the published user guide.

## Validation

- `./gradlew publishGuide`
- `rg -n "configuration files, but|build plugin\\. Please|configuration files,but|build plugin\\.Please|include::|snippet::|NO FILE|Unresolved" build/working/01-includes/configurationProperties/standard-optimizers.adoc build/working/02-docs-raw/all/guide build/working/02-docs-raw/all/index.html`
- `./gradlew :micronaut-doc-examples:micronaut-example-java:test :micronaut-aot-core:test --tests io.micronaut.aot.core.report.AotDiagnosticReportWriterTest :micronaut-aot-cli:test --tests io.micronaut.aot.cli.CliTest --continue`
- `git diff --check`

Paperclip: DEV-1087

---
###### ✨ This message was AI-generated using gpt-5.5
