### PR TITLE
Fix generated optimizer docs wording

### DIFF
--- a/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
+++ b/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
@@ -57,7 +57,7 @@ public class ConfigPropsGenerator {
                 writer.println("[cols=\"1,3,3\"]");
                 writer.println("|===");
                 writer.println("|Property|Description|Example value");
-                writer.println("| `" + module.id() + ".enabled` |Enables this optimization: " + trimTrailingPeriod(module.description()) + "|`true`");
+                writer.println("| `" + module.id() + ".enabled` |" + enabledDescription(module) + "|`true`");
                 for (Option option : module.options()) {
                     // Add 0-width space so that text wrapping works
                     var sample = option.sampleValue().replace(",", ",\u200B");
@@ -68,7 +68,13 @@ public class ConfigPropsGenerator {
         }
     }
 
-    private static String trimTrailingPeriod(String value) {
-        return value.endsWith(".") ? value.substring(0, value.length() - 1) : value;
+    private static String enabledDescription(AOTModule module) {
+        var description = normalizedDescription(module.description());
+        return description.isEmpty() ? "Enables this optimization" : "Enables this optimization: " + description;
+    }
+
+    private static String normalizedDescription(String value) {
+        var trimmed = value.trim();
+        return trimmed.endsWith(".") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
     }
 }

--- a/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
+++ b/aot-std-optimizers/src/configPropsGenerator/java/io/micronaut/aot/config/ConfigPropsGenerator.java
@@ -57,7 +57,7 @@ public class ConfigPropsGenerator {
                 writer.println("[cols=\"1,3,3\"]");
                 writer.println("|===");
                 writer.println("|Property|Description|Example value");
-                writer.println("| `" + module.id() + ".enabled` |Enables the " + module.description() + " optimization|`true`");
+                writer.println("| `" + module.id() + ".enabled` |Enables this optimization: " + trimTrailingPeriod(module.description()) + "|`true`");
                 for (Option option : module.options()) {
                     // Add 0-width space so that text wrapping works
                     var sample = option.sampleValue().replace(",", ",\u200B");
@@ -66,5 +66,9 @@ public class ConfigPropsGenerator {
                 writer.println("|===");
             }
         }
+    }
+
+    private static String trimTrailingPeriod(String value) {
+        return value.endsWith(".") ? value.substring(0, value.length() - 1) : value;
     }
 }

--- a/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/KnownMissingTypesSourceGenerator.java
+++ b/aot-std-optimizers/src/main/java/io/micronaut/aot/std/sourcegen/KnownMissingTypesSourceGenerator.java
@@ -48,7 +48,7 @@ import java.util.Set;
 public class KnownMissingTypesSourceGenerator extends AbstractCodeGenerator {
     public static final String ID = "known.missing.types";
     public static final Option OPTION = MetadataUtils.findMetadata(KnownMissingTypesSourceGenerator.class).get().options()[0];
-    public static final String DESCRIPTION = "Checks of existence of some types at build time instead of runtime";
+    public static final String DESCRIPTION = "Checks for the existence of some types at build time instead of runtime";
 
     private List<String> findMissingClasses(List<String> classNames) {
         var knownMissingClasses = new ArrayList<String>();

--- a/src/main/docs/guide/standardOptimizers.adoc
+++ b/src/main/docs/guide/standardOptimizers.adoc
@@ -4,6 +4,4 @@ Micronaut AOT includes standard optimizers that can be enabled or disabled in th
 Each optimizer is identified by its module id.
 To enable an optimizer, set `<module id>.enabled=true`.
 
-WARNING: These properties belong in the Micronaut AOT configuration used by the build plugin, not in the regular Micronaut application configuration files.
-
 include::{includedir}configurationProperties/standard-optimizers.adoc[]


### PR DESCRIPTION
## Summary

- Remove the duplicate AOT-configuration warning from the Standard Optimizers guide page.
- Make generated `<module>.enabled` descriptions read as user-facing documentation instead of `Enables the ... optimization` grammar.
- Fix the `known.missing.types` source metadata so the generated guide says `Checks for the existence...`.

## Validation

- `./gradlew publishGuide`
- `./gradlew :micronaut-doc-examples:micronaut-example-java:test`
- `./gradlew :micronaut-aot-std-optimizers:test`
- `git diff --check`

## Paperclip

- Subtask: [DEV-1183](/DEV/issues/DEV-1183)

---
###### ✨ This message was AI-generated using openai/gpt-5.5
