### PR TITLE
Start 3.2.x at 3.2.0-SNAPSHOT with core 5.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=3.1.1-SNAPSHOT
+projectVersion=3.2.0-SNAPSHOT
 projectGroup=io.micronaut.aot
 groovyVersion=4.0.13
 spockVersion=2.3-groovy-4.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 javapoet = "1.13.0"
-micronaut = "5.1.12"
+micronaut = "5.2.0"
 micronaut-picocli = "6.1.0"
 
 [libraries]


### PR DESCRIPTION
Starts the new minor branch `3.2.x` (created from `3.1.x`) at `3.2.0-SNAPSHOT` and moves it to Micronaut core 5.2.0.

Core 5.2 may only land in a new, unreleased minor of each library, so it does not go to `3.1.x`, whose minor is already released. Tracked in micronaut-projects/micronaut-core#13110.

Switching the default and Renovate base branch to `3.2.x` is left to the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)